### PR TITLE
Add Badges for README.md

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -70,3 +70,27 @@ jobs:
       - name: Cleanup temp folder
         run: |
           rm -rf ./tmp
+  
+  generate-badges:
+    name: Generate Badges
+    runs-on: ubuntu-latest
+    needs: [test-code, test-docker]
+
+    steps:
+      - name: Generate Unit Test Badge
+        uses: RubbaBoy/BYOB@v1.3.0
+        with:
+          NAME: unit-tests
+          LABEL: 'Unit Tests'
+          STATUS: ${{ needs.test-code.result }}
+          COLOR: ${{ needs.test-code.result == 'success' && 'green' || 'red' }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    
+      - name: Generate Docker Test Badge
+        uses: RubbaBoy/BYOB@v1.3.0
+        with:
+          NAME: docker-tests
+          LABEL: 'Docker Tests'
+          STATUS: ${{ needs.test-docker.result }}
+          COLOR: ${{ needs.test-docker.result == 'success' && 'green' || 'red' }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 [![GitHub release (latest by date)](https://img.shields.io/github/v/release/harshhome/diun-boost?style=flat)](https://github.com/harshhome/diun-boost/releases/latest)
 [![Docker Image Size (latest by tag)](https://img.shields.io/docker/image-size/harshbaldwa/diun-boost/latest?style=flat)](https://hub.docker.com/r/harshbaldwa/diun-boost)
 
+![Unit Tests](https://byob.yarr.is/harshhome/diun-boost/unit-tests)
+![Docker Tests](https://byob.yarr.is/harshhome/diun-boost/docker-tests)
+
 Automated [DIUN](https://crazymax.dev/diun/) File Provider YAML Generator for Smarter Docker Image Monitoring
 
 ## 📄 General Description


### PR DESCRIPTION
This pull request introduces a workflow to generate status badges for unit and Docker tests and updates the `README.md` file to display these badges. The changes aim to improve the visibility of test results directly in the repository's documentation.

### Workflow Updates:
* Added a new `generate-badges` job to the `.github/workflows/tests.yml` file. This job generates badges for unit tests and Docker tests using the `RubbaBoy/BYOB` GitHub Action. The badges reflect the test results (`success` or `failure`) with corresponding colors (`green` or `red`).

### Documentation Updates:
* Updated `README.md` to include the generated badges for unit tests and Docker tests. These badges provide a visual representation of the test statuses directly in the repository's README badge links