### PR TITLE
Support for WATCHBYDEFAULT env variable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
 
 jobs:
   release:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: "3.13"
 
       - name: Install dependencies
         run: |
@@ -49,14 +49,16 @@ jobs:
           docker run --rm -d --name diun-boost-test-container \
             -e DIUN_YAML_PATH="/tmp/config.yml" \
             -e LOG_LEVEL="DEBUG" \
+            -e WATCHBYDEFAULT="true" \
             -v ${{ github.workspace }}/tmp:/tmp \
             -v /var/run/docker.sock:/var/run/docker.sock \
+            -l 'diun.enable=true' \
             diun-boost-test
 
           echo "Waiting for 5 seconds..."
           sleep 5
 
-          if [[ ! -s ./tmp/config.yml ]]; then
+          if [[ ! -f ./tmp/config.yml ]]; then
             echo "ERROR: config.yml was not created or is empty!"
             docker logs diun-boost-test-container || true
             exit 1
@@ -66,11 +68,11 @@ jobs:
           fi
 
           docker stop diun-boost-test-container || true
-          
+
       - name: Cleanup temp folder
         run: |
           rm -rf ./tmp
-  
+
   generate-badges:
     name: Generate Badges
     runs-on: ubuntu-latest
@@ -81,16 +83,16 @@ jobs:
         uses: RubbaBoy/BYOB@v1.3.0
         with:
           NAME: unit-tests
-          LABEL: 'Unit Tests'
+          LABEL: "Unit Tests"
           STATUS: ${{ needs.test-code.result }}
           COLOR: ${{ needs.test-code.result == 'success' && 'green' || 'red' }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    
+
       - name: Generate Docker Test Badge
         uses: RubbaBoy/BYOB@v1.3.0
         with:
           NAME: docker-tests
-          LABEL: 'Docker Tests'
+          LABEL: "Docker Tests"
           STATUS: ${{ needs.test-docker.result }}
           COLOR: ${{ needs.test-docker.result == 'success' && 'green' || 'red' }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -54,18 +54,28 @@ docker run -d \
   -e DIUN_YAML_PATH=/config/config.yml \
   -e CRON_SCHEDULE="0 */6 * * *" \
   -e LOG_LEVEL=INFO \
+  -e WATCHBYDEFAULT=false \
   -v $(pwd)/config:/config \
   -v /var/run/docker.sock:/var/run/docker.sock \
   harshbaldwa/diun-boost:latest
 ```
-#### Environment Variables:
-- `DIUN_YAML_PATH`: Shared `config.yml` file path.
-- `CRON_SCHEDULE`: Cron schedule for generating the YAML file. Default is `0 */6 * * *`.
-- `LOG_LEVEL`: Set the log level (DEBUG, INFO, WARNING, ERROR). Default is INFO.
 
-#### Volume Mounts:
-- `/var/run/docker.sock`: Required for Docker API access.
-- `$(pwd)/config`: Directory for the generated `config.yml` file.
+#### Environment Variables
+
+| Variable        | Description                                                                                                                                           | Default Value        |
+|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------|
+| `DIUN_YAML_PATH` | Path to the shared `config.yml` file that DIUN will read.                                                                                               | `/config/config.yml`  |
+| `CRON_SCHEDULE`  | Cron schedule expression to control how often the YAML file is regenerated.                                                                           | `0 */6 * * *`          |
+| `LOG_LEVEL`      | Logging level for diun-boost. Available options: `DEBUG`, `INFO`, `WARNING`, `ERROR`.                                                                  | `INFO`                |
+| `WATCHBYDEFAULT` | Set to `true` to watch **all running containers** by default. <br> However, any container explicitly labeled with `diun.enable=false` will always be excluded. <br> If set to `false`, only containers with the label `diun.enable=true` are watched. | `false`               |
+
+
+#### Volume Mounts
+
+| Mount Path               | Description                                           |
+|----------------------------|-------------------------------------------------------|
+| `/var/run/docker.sock`     | Required for accessing the Docker API from the container. |
+| `$(pwd)/config`            | Local directory to store the generated `config.yml` file.  |
 
 ### Using Docker Compose
 

--- a/app/docker_client.py
+++ b/app/docker_client.py
@@ -1,5 +1,7 @@
 from typing import List
 
+from loguru import logger
+
 from docker import from_env
 from docker.client import DockerClient
 from docker.models.containers import Container
@@ -15,15 +17,20 @@ def get_docker_client() -> DockerClient:
     return from_env()
 
 
-def get_running_containers(client: DockerClient) -> List[Container]:
+def get_running_containers(client: DockerClient, m_all: bool) -> List[Container]:
     """
     Returns a list of running containers
     
     Args:
         client (docker.DockerClient): A Docker client instance.
+        m_all (bool): If True, monitor all containers, else only those with the label "diun.enable=true".
     
     Returns:
         List[docker.models.containers.Container]: A list of running containers.
     """
     filters = {"status": "running"}
-    return client.containers.list(filters=filters)
+    if not m_all:
+        filters["label"] = "diun.enable=true"
+    containers = client.containers.list(filters=filters)
+    containers = [c for c in containers if c.labels.get("diun.enable") != "false"]
+    return containers

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,9 +15,4 @@ RUN chmod +x /entrypoint.sh
 
 ENV PYTHONPATH=/app
 
-LABEL org.opencontainers.image.title="diun-boost"
-LABEL org.opencontainers.image.description="Generate config.yml automatically from running containers"
-LABEL org.opencontainers.image.version="1.0.0"
-LABEL org.opencontainers.image.authors="Harshvardhan Baldwa docker@harshbaldwa.com"
-
 ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -8,6 +8,7 @@ trap 'echo "Received SIGTERM, stopping cron..."; pkill cron; exit 0' TERM INT
     echo "export DIUN_YAML_PATH=\"${DIUN_YAML_PATH:-/config/config.yml}\""
     echo "export CRON_SCHEDULE=\"${CRON_SCHEDULE:-0 */6 * * *}\""
     echo "export LOG_LEVEL=\"${LOG_LEVEL:-INFO}\""
+    echo "export WATCHBYDEFAULT=\"${WATCHBYDEFAULT:-false}\""
     echo "export PYTHONPATH=/app"
 } > /etc/cron.d/env-vars
 


### PR DESCRIPTION
This pull request introduces several changes to enhance the functionality of the `diun-boost` application, particularly around container monitoring, configuration management, and documentation. The key updates include adding a new feature to monitor containers based on a configurable default behavior, improving YAML file handling, and updating the documentation to reflect these changes.

### New Feature: Configurable Container Monitoring
* Added a new environment variable `WATCHBYDEFAULT` to control whether all running containers are monitored by default or only those explicitly labeled with `diun.enable=true`. This affects both the Docker container runtime (`docker/entrypoint.sh`) and the Python application logic (`app/main.py`, `app/docker_client.py`). [[1]](diffhunk://#diff-4f5cabe26761257a4d685a6edc7a43e0fe0f78762f50eeb48530f2bd3b3ee7caR11) [[2]](diffhunk://#diff-990f7e4140fab1ad82afc787505090b64d4024e63a891405cd9085e7e6b249ddR40-R53) [[3]](diffhunk://#diff-afac8c6f411ea42a956e30fdfad709619bd2f2e36fca33984b9245e25cf8d41cL18-R36)

### YAML File Management Enhancements
* Introduced a new function `create_empty_yaml` to ensure an empty YAML file is created during the first run if it does not already exist (`app/yaml_helper.py`, `app/main.py`). [[1]](diffhunk://#diff-75964ee42ce63406f6f38796b7b0367b4b415d7f234e52d9ee235de6afefa511R74-R85) [[2]](diffhunk://#diff-990f7e4140fab1ad82afc787505090b64d4024e63a891405cd9085e7e6b249ddR40-R53)
* Modified the `compare_yaml_files` function to handle cases where the existing YAML file is empty (`app/yaml_helper.py`).

### Documentation Updates
* Updated the `README.md` to include detailed descriptions of the new `WATCHBYDEFAULT` environment variable and its behavior. Also reformatted the environment variables and volume mounts sections into tables for better readability.

### Code Quality and Consistency
* Standardized the use of double quotes for strings across multiple workflow files (`.github/workflows/release.yml`, `.github/workflows/tests.yml`). [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L6-R6) [[2]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL20-R20) [[3]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL84-R86) [[4]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL93-R95)

### Miscellaneous
* Removed unused Docker image labels from the `Dockerfile` to clean up metadata (`docker/Dockerfile`).