### PR TITLE
Support for DOCKER_COMPOSE_METADATA env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ docker run -d \
   -e CRON_SCHEDULE="0 */6 * * *" \
   -e LOG_LEVEL=INFO \
   -e WATCHBYDEFAULT=false \
+  -e DOCKER_COMPOSE_METADATA=false \
   -v $(pwd)/config:/config \
   -v /var/run/docker.sock:/var/run/docker.sock \
   harshbaldwa/diun-boost:latest
@@ -68,6 +69,7 @@ docker run -d \
 | `CRON_SCHEDULE`  | Cron schedule expression to control how often the YAML file is regenerated.                                                                           | `0 */6 * * *`          |
 | `LOG_LEVEL`      | Logging level for diun-boost. Available options: `DEBUG`, `INFO`, `WARNING`, `ERROR`.                                                                  | `INFO`                |
 | `WATCHBYDEFAULT` | Set to `true` to watch **all running containers** by default. <br> However, any container explicitly labeled with `diun.enable=false` will always be excluded. <br> If set to `false`, only containers with the label `diun.enable=true` are watched. | `false`               |
+| `DOCKER_COMPOSE_METADATA` | Set to `true` to include Docker Compose metadata in the generated YAML file. <br> This is useful for identifying containers in a multi-container setup as well as for notifications with DIUN. <br> If set to `false`, only the container name will be used. | `false`               |
 
 
 #### Volume Mounts
@@ -91,6 +93,8 @@ services:
         - DIUN_YAML_PATH=/config/config.yml
         - CRON_SCHEDULE="0 */6 * * *"
         - LOG_LEVEL=INFO
+        - WATCHBYDEFAULT=false
+        - DOCKER_COMPOSE_METADATA=false
     restart: unless-stopped
 ```
 
@@ -138,6 +142,7 @@ services:
       - CRON_SCHEDULE=0 */6 * * *
       - LOG_LEVEL=INFO
       - WATCHBYDEFAULT=false
+      - DOCKER_COMPOSE_METADATA=false
     restart: unless-stopped
 ```
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -9,6 +9,7 @@ trap 'echo "Received SIGTERM, stopping cron..."; pkill cron; exit 0' TERM INT
     echo "export CRON_SCHEDULE=\"${CRON_SCHEDULE:-0 */6 * * *}\""
     echo "export LOG_LEVEL=\"${LOG_LEVEL:-INFO}\""
     echo "export WATCHBYDEFAULT=\"${WATCHBYDEFAULT:-false}\""
+    echo "export DOCKER_COMPOSE_METADATA=\"${DOCKER_COMPOSE_METADATA:-false}\""
     echo "export PYTHONPATH=/app"
 } > /etc/cron.d/env-vars
 


### PR DESCRIPTION
This pull request introduces a new feature to include Docker Compose metadata in the DIUN YAML configuration, along with updates to the documentation and codebase to support this functionality. The changes primarily revolve around adding a new environment variable, `DOCKER_COMPOSE_METADATA`, and modifying the code to handle this new option.

### Feature Addition: Docker Compose Metadata
* **Environment Variable**: Added `DOCKER_COMPOSE_METADATA` to control whether Docker Compose metadata (project and service names) is included in the DIUN YAML configuration. Updated `README.md` to document this new variable and its usage. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R58) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R72) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R96-R97) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R145)
* **Entrypoint Script**: Updated `docker/entrypoint.sh` to export the new `DOCKER_COMPOSE_METADATA` variable with a default value of `false`.

### Code Changes to Support Metadata
* **Function Updates**: Modified `create_diun_yaml` in `app/yaml_helper.py` to accept a `compose_track` argument and include Docker Compose metadata in the YAML configuration if the flag is enabled. [[1]](diffhunk://#diff-75964ee42ce63406f6f38796b7b0367b4b415d7f234e52d9ee235de6afefa511L11-R18) [[2]](diffhunk://#diff-75964ee42ce63406f6f38796b7b0367b4b415d7f234e52d9ee235de6afefa511R35-L35)
* **Main Logic**: Updated `app/main.py` to read the `DOCKER_COMPOSE_METADATA` environment variable, pass it as an argument to `run_tasks`, and log whether Docker Compose metadata tracking is enabled. [[1]](diffhunk://#diff-990f7e4140fab1ad82afc787505090b64d4024e63a891405cd9085e7e6b249ddL22-R25) [[2]](diffhunk://#diff-990f7e4140fab1ad82afc787505090b64d4024e63a891405cd9085e7e6b249ddR41-R58)