### PR TITLE
HOTFIX - current_version Metadata

### DIFF
--- a/app/yaml_helper.py
+++ b/app/yaml_helper.py
@@ -40,6 +40,7 @@ def create_diun_yaml(containers: List[Container], m_all: bool, compose_track: bo
             compose_service = container.labels["com.docker.compose.service"]
             entry.update({
                 "metadata": {
+                    "current_tag": tag,
                     "compose_project": compose_project,
                     "compose_service": compose_service
                 }


### PR DESCRIPTION
This pull request includes a small enhancement to the `create_diun_yaml` function in the `app/yaml_helper.py` file. The change adds a new `"current_tag"` field to the `metadata` dictionary, which likely provides additional context about the container's current tag.