### PR TITLE
Update environment variable handling in entrypoint.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,14 +51,14 @@ This tool simplifies managing large DIUN configurations by automatically creatin
 ```bash
 docker run -d \
   --name diun-boost \
-  -e DIUN_YAML_PATH=/config/config.yml \
+  -e DIUN_YAML_PATH="/config/config.yml" \
   -e CRON_SCHEDULE="0 */6 * * *" \
-  -e LOG_LEVEL=INFO \
-  -e WATCHBYDEFAULT=false \
-  -e DOCKER_COMPOSE_METADATA=false \
-  -v $(pwd)/config:/config \
-  -v /var/run/docker.sock:/var/run/docker.sock \
-  harshbaldwa/diun-boost:latest
+  -e LOG_LEVEL="INFO" \
+  -e WATCHBYDEFAULT="false" \
+  -e DOCKER_COMPOSE_METADATA="false" \
+  -v "$(pwd)/config:/config" \
+  -v "/var/run/docker.sock:/var/run/docker.sock" \
+  harshbaldwa/diun-boost:1.2.1
 ```
 
 #### Environment Variables
@@ -85,16 +85,16 @@ docker run -d \
 services:
   diun-boost:
     container_name: diun-boost
-    image: harshbaldwa/diun-boost:latest
+    image: harshbaldwa/diun-boost:1.2.1
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./config:/config
     environment:
-        - DIUN_YAML_PATH=/config/config.yml
-        - CRON_SCHEDULE="0 */6 * * *"
-        - LOG_LEVEL=INFO
-        - WATCHBYDEFAULT=false
-        - DOCKER_COMPOSE_METADATA=false
+      - DIUN_YAML_PATH=/config/config.yml
+      - CRON_SCHEDULE=0 */6 * * *
+      - LOG_LEVEL=INFO
+      - WATCHBYDEFAULT=false
+      - DOCKER_COMPOSE_METADATA=false
     restart: unless-stopped
 ```
 
@@ -133,7 +133,7 @@ services:
     
   diun-boost:
     container_name: diun-boost
-    image: harshbaldwa/diun-boost:1.2.0
+    image: harshbaldwa/diun-boost:1.2.1
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./config:/config

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -4,9 +4,9 @@ set -e
 
 trap 'echo "Received SIGTERM, stopping cron..."; pkill cron; exit 0' TERM INT
 
+export CRON_SANTIZED=$(echo "${CRON_SCHEDULE:-0 */6 * * *}" | tr -d '"'\''')
 {
     echo "export DIUN_YAML_PATH=\"${DIUN_YAML_PATH:-/config/config.yml}\""
-    echo "export CRON_SCHEDULE=\"${CRON_SCHEDULE:-0 */6 * * *}\""
     echo "export LOG_LEVEL=\"${LOG_LEVEL:-INFO}\""
     echo "export WATCHBYDEFAULT=\"${WATCHBYDEFAULT:-false}\""
     echo "export DOCKER_COMPOSE_METADATA=\"${DOCKER_COMPOSE_METADATA:-false}\""
@@ -14,7 +14,7 @@ trap 'echo "Received SIGTERM, stopping cron..."; pkill cron; exit 0' TERM INT
 } > /etc/cron.d/env-vars
 
 {
-    echo "${CRON_SCHEDULE:-0 */6 * * *} root /bin/sh -c '. /etc/cron.d/env-vars && /usr/local/bin/python /app/app/main.py >> /proc/1/fd/1 2>&1'"
+    echo "${CRON_SANTIZED} root /bin/sh -c '. /etc/cron.d/env-vars && /usr/local/bin/python /app/app/main.py >> /proc/1/fd/1 2>&1'"
 } > /etc/cron.d/diunboost
 
 chmod 0644 /etc/cron.d/env-vars /etc/cron.d/diunboost


### PR DESCRIPTION
This pull request includes updates to improve configuration consistency, enhance environment variable handling, and update the Docker image version. The most important changes include standardizing the use of quotes in environment variables, introducing a sanitized CRON schedule variable, and updating the Docker image version in multiple places.

### Configuration Consistency:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L54-R61): Standardized the use of quotes around environment variable values in the example `docker run` command and updated volume paths to use quotes for consistency.

### Environment Variable Handling:

* [`docker/entrypoint.sh`](diffhunk://#diff-4f5cabe26761257a4d685a6edc7a43e0fe0f78762f50eeb48530f2bd3b3ee7caR7-R17): Introduced a new `CRON_SANTIZED` variable to remove quotes from the CRON schedule, ensuring compatibility with the cron service. Updated the CRON schedule definition in the `diunboost` cron job to use this sanitized variable.

### Docker Image Version Updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L88-R94): Updated the Docker image version from `latest` and `1.2.0` to `1.2.1` in both the `docker run` command and the `docker-compose` examples. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L88-R94) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L136-R136)