### PR TITLE
Add custom metadata preservation feature and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ Tags that don’t follow semantic versioning — like:
 - `latest`, `20240518`, `final-build`, `beta`
 - Are matched **exactly**, no version logic is applied.
 
+### 📝 Custom Metadata Preservation
+
+Add your own keys under `metadata` in `config.yml` entries and diun-boost will
+keep them on regeneration (it still updates `current_tag` and optional Docker
+Compose metadata).
+
 ### 🔍 Test Regex Live
 👉 Explore the version matching logic and patterns here: [Regex 101 pattern](https://regex101.com/r/u8sAuo/1)
 

--- a/app/main.py
+++ b/app/main.py
@@ -6,7 +6,8 @@ from loguru import logger
 
 from app.docker_client import get_docker_client, get_running_containers
 from app.yaml_helper import (compare_yaml_files, create_diun_yaml,
-                             create_empty_yaml, write_yaml_to_file)
+                             create_empty_yaml, load_yaml_entries,
+                             merge_custom_metadata, write_yaml_to_file)
 
 
 def setup_logging(level: str) -> None:
@@ -25,7 +26,9 @@ def setup_logging(level: str) -> None:
 def run_tasks(output_path: str, m_all: bool, compose_track: bool) -> None:
     client = get_docker_client()
     containers = get_running_containers(client, m_all)
+    existing_entries = load_yaml_entries(output_path)
     diun_entries = create_diun_yaml(containers, m_all, compose_track)
+    diun_entries = merge_custom_metadata(diun_entries, existing_entries)
 
     if compare_yaml_files(output_path, diun_entries):
         write_yaml_to_file(diun_entries, output_path)

--- a/tests/test_yaml_helper.py
+++ b/tests/test_yaml_helper.py
@@ -1,0 +1,51 @@
+from app.yaml_helper import merge_custom_metadata
+
+
+def test_merge_custom_metadata_preserves_custom_keys():
+    existing = [
+        {"name": "repo:1", "metadata": {
+            "current_tag": "1",
+            "team": "infra",
+            "priority": 2,
+        }}
+    ]
+    generated = [
+        {"name": "repo:1", "notify_on": ["update"], "metadata": {
+            "current_tag": "1",
+        }}
+    ]
+
+    merged = merge_custom_metadata(generated, existing)
+
+    assert merged[0]["metadata"]["current_tag"] == "1"
+    assert merged[0]["metadata"]["team"] == "infra"
+    assert merged[0]["metadata"]["priority"] == 2
+
+
+def test_merge_custom_metadata_ignores_auto_keys():
+    existing = [
+        {"name": "repo:1", "metadata": {
+            "compose_project": "app",
+            "compose_service": "web",
+            "note": "keep",
+        }}
+    ]
+    generated = [
+        {"name": "repo:1", "metadata": {"current_tag": "1"}}
+    ]
+
+    merged = merge_custom_metadata(generated, existing)
+
+    assert merged[0]["metadata"]["current_tag"] == "1"
+    assert merged[0]["metadata"]["note"] == "keep"
+    assert "compose_project" not in merged[0]["metadata"]
+    assert "compose_service" not in merged[0]["metadata"]
+
+
+def test_merge_custom_metadata_matches_by_name():
+    existing = [{"name": "repo:1", "metadata": {"team": "infra"}}]
+    generated = [{"name": "repo:2", "metadata": {"current_tag": "2"}}]
+
+    merged = merge_custom_metadata(generated, existing)
+
+    assert "team" not in merged[0]["metadata"]


### PR DESCRIPTION
- Introduced functionality to preserve user-defined metadata during regeneration in `merge_custom_metadata`.
- Updated `README.md` to document the new custom metadata feature.
- Added unit tests for custom metadata merging in `test_yaml_helper.py`.