### PR TITLE
feat: implement targeted dashboard refresh and enhance dashboard functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
-# diun-boost  🚀 🐳 📦
+# diun-boost
 
 [![GitHub release (latest by date)](https://img.shields.io/github/v/release/harshhome/diun-boost?style=flat)](https://github.com/harshhome/diun-boost/releases/latest)
 [![Docker Image Size (latest by tag)](https://img.shields.io/docker/image-size/harshbaldwa/diun-boost/latest?style=flat)](https://hub.docker.com/r/harshbaldwa/diun-boost)
 [![GitHub Stars](https://img.shields.io/github/stars/harshhome/diun-boost?style=flat)](https://github.com/harshhome/diun-boost/stargazers)
 [![Docker Pulls](https://img.shields.io/docker/pulls/harshbaldwa/diun-boost?style=flat)](https://hub.docker.com/r/harshbaldwa/diun-boost)
 [![Issues](https://img.shields.io/github/issues/harshhome/diun-boost?style=flat)](https://github.com/harshhome/diun-boost/issues)
-
 [![GitHub Repo](https://img.shields.io/badge/GitHub-Repo-black?logo=github&style=flat)](https://github.com/harshhome/diun-boost)
 [![DockerHub](https://img.shields.io/badge/DockerHub-Repo-blue?logo=docker&style=flat)](https://hub.docker.com/r/harshbaldwa/diun-boost)
 [![Made with Python](https://img.shields.io/badge/Made%20with-Python-yellow?logo=python&style=flat)](https://www.python.org/)
@@ -13,128 +12,223 @@
 ![Unit Tests](https://byob.yarr.is/harshhome/diun-boost/unit-tests)
 ![Docker Tests](https://byob.yarr.is/harshhome/diun-boost/docker-tests)
 
-Automated [DIUN](https://crazymax.dev/diun/) File Provider YAML Generator for Smarter Docker Image Monitoring
+Automated DIUN file-provider config generation plus a lightweight dashboard for reviewing pending Docker image updates.
 
-## 📄 General Description
+## What diun-boost does
 
-**diun-boost** is a ⚡ **utility tool** ⚡ that dynamically generates a `config.yml` file designed to be used with DIUN's [File Provider](https://crazymax.dev/diun/providers/file/).
+diun-boost is a companion tool for [DIUN](https://crazymax.dev/diun/):
 
-> *Important*: diun-boost **only generates** the configuration file (`config.yml`) for DIUN. It does **NOT monitor** container updates itself. DIUN will use the generated file to monitor images! 🔍
+- it scans your running Docker containers
+- generates a DIUN file-provider YAML (`config.yml`)
+- preserves your custom metadata across regenerations
+- builds a dashboard snapshot (`dashboard.json`) from DIUN state
+- serves a small web UI for grouped, review-friendly update visibility
 
-This tool simplifies managing large DIUN configurations by automatically creating version-aware watch entries based on your running Docker containers and generate rules that monitors only newer [semver](https://semver.org) tags.
+Important:
+- diun-boost does not replace DIUN
+- DIUN still performs the actual update monitoring
+- diun-boost prepares DIUN input and presents pending results in a cleaner dashboard
 
-## ✨ Features
+## What's new in the current version
 
-### 🧠 Smart Semantic Versioning Support
+Recent changes added a proper dashboard-oriented workflow:
 
-Version matching is **depth-aware** — only tags with the **same number of components** (segments) are compared:
+- built-in FastAPI dashboard UI
+- generated `dashboard.json` snapshot alongside `config.yml`
+- separate cron schedules for config refreshes and dashboard refreshes
+- manual modes for `--config-only` and `--dashboard-only`
+- targeted dashboard refreshes for currently pending Compose services
+- refresh API endpoint at `POST /api/report/refresh`
+- preserved custom metadata on YAML regeneration
+- initial startup now creates the YAML file only if it does not already exist
 
-- ✅ `1.0.0` matches:
-  - `1.0.1`, `1.1.0`, `2.0.0`
-- ✅ `1.0` matches:
-  - `1.1`, `2.0`
-- ✅ `1.2.3.4` matches:
-  - `1.2.3.5`, `1.2.4.0`, `2.0.0.0`
-- ❌ No match to shorter (`1.0`, `1`) or longer (`1.0.0.1`) tags
+## Features
 
-> 📏 All segments must match in **depth** and be **equal or greater** in value.
+### Smart version-aware tag matching
 
-### 🏷️ Arbitrary Prefix Support
+Version matching is depth-aware, so only tags with the same number of version segments are compared.
 
-Supports any prefix (e.g. `v`, `pg`, `nodejs-`, `redis-`), preserving it in all matches:
+Examples:
+- `1.0.0` matches `1.0.1`, `1.1.0`, `2.0.0`
+- `1.0` matches `1.1`, `2.0`
+- `1.2.3.4` matches `1.2.3.5`, `1.2.4.0`, `2.0.0.0`
+- `1.0.0` does not match `1.0`, `1`, or `1.0.0.1`
 
-- Examples:
-  - `v1.0.0`, `pg13.5.1`, `nodejs-18.16.0`, `nginx1.25.3`
+### Prefix-aware tags
 
-### 🎯 Suffix-Aware Version Comparison
+Arbitrary prefixes are preserved in generated matching rules.
 
-Suffixes and their versions are independently compared:
+Examples:
+- `v1.0.0`
+- `pg13.5.1`
+- `nodejs-18.16.0`
+- `nginx1.25.3`
 
-- A tag like `v1.2.0.12-build12` will match:
-  - `v1.2.0.12-build13` ✅ (same main version, higher suffix version)
-  - `v1.2.0.13-build11` ✅ (higher main version, lower suffix version still okay)
-- Both the **main version** and **suffix version** are evaluated using depth-aware comparison
+### Suffix-aware comparisons
 
-### ✅ Non-Semver & Static Tag Matching
+Suffixes are handled independently from the main version.
 
-Tags that don’t follow semantic versioning — like:
-- `latest`, `20240518`, `final-build`, `beta`
-- Are matched **exactly**, no version logic is applied.
+Example:
+- `v1.2.0.12-build12` can match `v1.2.0.12-build13`
+- `v1.2.0.12-build12` can also match `v1.2.0.13-build11`
 
-### 📝 Custom Metadata Preservation
+### Exact matching for non-semver tags
 
-Add your own keys under `metadata` in `config.yml` entries and diun-boost will
-keep them on regeneration (it still updates `current_tag` and optional Docker
-Compose metadata).
+Non-semver or static tags are matched exactly.
 
-### 🔍 Test Regex Live
-👉 Explore the version matching logic and patterns here: [Regex 101 pattern](https://regex101.com/r/u8sAuo/1)
+Examples:
+- `latest`
+- `20240518`
+- `final-build`
+- `beta`
 
-### 🤏 Minimal Setup:
-- Works out of the box using Docker 🐳.
-- Supports linux/amd64 and linux/arm64 architectures.
-- Small and lightweight image (~50MB) 💾
-- No external dependencies required.
-- Built using `python:slim` base image with minimal runtime footprint.
+### Custom metadata preservation
 
-## 🛠️ How to Run
+You can add your own keys under `metadata` in generated DIUN entries. diun-boost keeps those keys when it regenerates the file, while still updating its own auto-managed metadata:
 
-### Using `docker run`
+- `current_tag`
+- `current_digest`
+- `compose_project`
+- `compose_service`
+
+### Dashboard for pending updates
+
+The dashboard snapshot groups updates by Compose project and shows:
+
+- service name
+- update type (`tag_bump` or `digest_refresh`)
+- current tag
+- latest tag
+- summary counts for projects, services, tag bumps, and digest refreshes
+
+### Split refresh pipeline
+
+The container now runs two cron-driven refresh paths:
+
+- config refresh: updates `config.yml`
+- dashboard refresh: updates `dashboard.json`
+
+This makes it possible to tune config generation and dashboard refresh cadence separately.
+
+### Targeted dashboard refreshes
+
+The web UI refresh action uses `POST /api/report/refresh`, which tries to refresh only the Compose services currently shown as pending. If there are no pending services, it reuses the existing empty snapshot without calling Docker or DIUN again.
+
+## How it works
+
+At container startup:
+
+1. diun-boost creates the output YAML file if it does not already exist
+2. it performs an initial config-only refresh
+3. it starts cron for scheduled refreshes
+4. it starts the dashboard web server with Uvicorn
+
+Scheduled jobs:
+
+- `CRON_SCHEDULE` runs `python /app/app/main.py --config-only`
+- `DIUN_DASHBOARD_CRON_SCHEDULE` runs `python /app/app/main.py --dashboard-only`
+
+Manual modes:
+
+- combined refresh: `python /app/app/main.py`
+- first run marker: `python /app/app/main.py --first-run`
+- config only: `python /app/app/main.py --config-only`
+- dashboard only: `python /app/app/main.py --dashboard-only`
+
+## Dashboard requirements
+
+For the dashboard to group updates by project and service, your generated YAML entries need Docker Compose metadata.
+
+Recommended setting:
+
+```env
+DOCKER_COMPOSE_METADATA=true
+```
+
+If Compose metadata is disabled, diun-boost can still generate `config.yml`, but the grouped dashboard view will have little or no useful project/service data.
+
+## Environment variables
+
+| Variable | Description | Default |
+|---|---|---|
+| `DIUN_YAML_PATH` | Path to the generated DIUN file-provider YAML. | `/config/config.yml` |
+| `DIUN_DASHBOARD_JSON_PATH` | Path to the generated dashboard snapshot JSON. | `/config/dashboard.json` |
+| `CRON_SCHEDULE` | Cron expression for regenerating `config.yml`. | `0 */6 * * *` |
+| `DIUN_DASHBOARD_CRON_SCHEDULE` | Cron expression for regenerating `dashboard.json`. | `7 */6 * * *` |
+| `LOG_LEVEL` | Logging level: `DEBUG`, `INFO`, `WARNING`, `ERROR`. | `INFO` |
+| `WATCHBYDEFAULT` | If `true`, watch all running containers except those explicitly labeled `diun.enable=false`. If `false`, only watch containers labeled `diun.enable=true`. | `false` |
+| `DOCKER_COMPOSE_METADATA` | If `true`, include `compose_project` and `compose_service` metadata in generated entries. Strongly recommended for dashboard use. | `false` |
+| `DIUN_CONTAINER_NAME` | Name of the running DIUN container that diun-boost queries for latest/manifests data. | `diun` |
+| `DIUN_DASHBOARD_APP_NAME` | Display name shown in the dashboard UI. | `DIUN Dashboard` |
+| `DIUN_DASHBOARD_BIND_HOST` | Host interface for the dashboard web server. | `0.0.0.0` |
+| `DIUN_DASHBOARD_BIND_PORT` | Port for the dashboard web server. | `8000` |
+
+## Docker run
 
 ```bash
 docker run -d \
   --name diun-boost \
+  -p 8000:8000 \
   -e DIUN_YAML_PATH="/config/config.yml" \
+  -e DIUN_DASHBOARD_JSON_PATH="/config/dashboard.json" \
   -e CRON_SCHEDULE="0 */6 * * *" \
+  -e DIUN_DASHBOARD_CRON_SCHEDULE="7 */6 * * *" \
   -e LOG_LEVEL="INFO" \
   -e WATCHBYDEFAULT="false" \
-  -e DOCKER_COMPOSE_METADATA="false" \
+  -e DOCKER_COMPOSE_METADATA="true" \
+  -e DIUN_CONTAINER_NAME="diun" \
   -v "$(pwd)/config:/config" \
   -v "/var/run/docker.sock:/var/run/docker.sock" \
-  harshbaldwa/diun-boost:1.3.0
+  harshbaldwa/diun-boost:latest
 ```
 
-#### Environment Variables
+Then open:
 
-| Variable        | Description                                                                                                                                           | Default Value        |
-|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------|
-| `DIUN_YAML_PATH` | Path to the shared `config.yml` file that DIUN will read.                                                                                               | `/config/config.yml`  |
-| `CRON_SCHEDULE`  | Cron schedule expression to control how often the YAML file is regenerated.                                                                           | `0 */6 * * *`          |
-| `LOG_LEVEL`      | Logging level for diun-boost. Available options: `DEBUG`, `INFO`, `WARNING`, `ERROR`.                                                                  | `INFO`                |
-| `WATCHBYDEFAULT` | Set to `true` to watch **all running containers** by default. <br> However, any container explicitly labeled with `diun.enable=false` will always be excluded. <br> If set to `false`, only containers with the label `diun.enable=true` are watched. | `false`               |
-| `DOCKER_COMPOSE_METADATA` | Set to `true` to include Docker Compose metadata in the generated YAML file. <br> This is useful for identifying containers in a multi-container setup as well as for notifications with DIUN. <br> If set to `false`, only the container name will be used. | `false`               |
+- dashboard UI: `http://localhost:8000/`
+- raw snapshot: `http://localhost:8000/api/report`
+- health check: `http://localhost:8000/healthz`
 
-
-#### Volume Mounts
-
-| Mount Path               | Description                                           |
-|----------------------------|-------------------------------------------------------|
-| `/var/run/docker.sock`     | Required for accessing the Docker API from the container. |
-| `$(pwd)/config`            | Local directory to store the generated `config.yml` file.  |
-
-### Using Docker Compose
+## Docker Compose example
 
 ```yaml
 services:
+  diun:
+    container_name: diun
+    image: crazymax/diun:latest
+    volumes:
+      - ./data:/data
+      - ./diun.yml:/diun.yml:ro
+      - ./config:/config:ro
+    environment:
+      - TZ=America/New_York
+    restart: unless-stopped
+
   diun-boost:
     container_name: diun-boost
-    image: harshbaldwa/diun-boost:1.3.0
+    image: harshbaldwa/diun-boost:latest
+    depends_on:
+      - diun
+    ports:
+      - "8000:8000"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./config:/config
     environment:
       - DIUN_YAML_PATH=/config/config.yml
+      - DIUN_DASHBOARD_JSON_PATH=/config/dashboard.json
       - CRON_SCHEDULE=0 */6 * * *
+      - DIUN_DASHBOARD_CRON_SCHEDULE=7 */6 * * *
       - LOG_LEVEL=INFO
       - WATCHBYDEFAULT=false
-      - DOCKER_COMPOSE_METADATA=false
+      - DOCKER_COMPOSE_METADATA=true
+      - DIUN_CONTAINER_NAME=diun
+      - DIUN_DASHBOARD_APP_NAME=DIUN Dashboard
     restart: unless-stopped
 ```
 
->**🔥 Tip**: Adjust volume mounts to match your environment.
+## DIUN configuration example
 
-### 📜 Sample Dummy Code for Diun
-Example base `diun.yml` file for DIUN:
+Base `diun.yml` for DIUN:
 
 ```yaml
 watch:
@@ -149,46 +243,61 @@ providers:
   file:
     filename: /config/config.yml
 ```
-`docker-compose.yml` file for DIUN and **diun-boost**:
+
+## Example generated entry
 
 ```yaml
-services:
-  diun:
-    container_name: diun
-    image: crazymax/diun:latest
-    volumes:
-      - ./data:/data
-      - ./diun.yml:/diun.yml:ro
-      - ./config:/config:ro
-    environment:
-      - "TZ=America/New_York"
-    restart: unless-stopped
-    
-  diun-boost:
-    container_name: diun-boost
-    image: harshbaldwa/diun-boost:1.3.0
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-      - ./config:/config
-    environment:
-      - DIUN_YAML_PATH=/config/config.yml
-      - CRON_SCHEDULE=0 */6 * * *
-      - LOG_LEVEL=INFO
-      - WATCHBYDEFAULT=false
-      - DOCKER_COMPOSE_METADATA=false
-    restart: unless-stopped
+- name: linuxserver/sonarr:4.0.17
+  notify_on:
+    - new
+    - update
+  metadata:
+    current_tag: 4.0.17
+    current_digest: sha256:...
+    compose_project: arr-stack
+    compose_service: sonarr
+    team: media
+    severity: normal
+  watch_repo: true
+  include_tags:
+    - ^((?:5|[6-9]\d*)\.\d+\.\d+|4\.(?:1|[2-9]\d*)\.\d+|4.0\.(?:17|[1-9]\d*))$
 ```
 
-## ❤️ Support This Project
+User-defined metadata like `team` and `severity` is preserved across future regenerations.
 
-If you find diun-boost useful, fuel its growth by buying me a coffee!
+## Dashboard API
 
-[!["Buy Me A Coffee"](https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png)](https://www.buymeacoffee.com/harshbaldwa)
+- `GET /` - HTML dashboard
+- `GET /api/report` - return the current `dashboard.json`
+- `POST /api/report/refresh` - perform a targeted live refresh and return the refreshed snapshot
+- `GET /healthz` - simple health endpoint
 
-Every coffee helps keep open-source alive and thriving! 🚀
+## Notes and behavior
 
-## 📜 License
+- Containers with `diun.enable=false` are always excluded.
+- When `WATCHBYDEFAULT=false`, only containers with `diun.enable=true` are included.
+- When `WATCHBYDEFAULT=true`, all running containers are included except explicit opt-outs.
+- The dashboard distinguishes between:
+  - `tag_bump`: current tag differs from latest tag
+  - `digest_refresh`: tag is unchanged but image digest changed
+- `dashboard.json` is only rewritten when content changes.
+- `config.yml` is only rewritten when content changes.
+- If `dashboard.json` already shows no pending services, the targeted refresh path returns that snapshot as-is.
+
+## Local development
+
+Run the test suite from the repository root:
+
+```bash
+pytest
+```
+
+## Support
+
+If you find diun-boost useful, consider supporting the project:
+
+[Buy Me A Coffee](https://www.buymeacoffee.com/harshbaldwa)
+
+## License
 
 This project is licensed under the MIT License.
-
-> Made with ❤️ by **Harshvardhan Baldwa** for the homelab and DevOps community!

--- a/app/dashboard_snapshot.py
+++ b/app/dashboard_snapshot.py
@@ -4,6 +4,7 @@ import json
 import re
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
+from typing import Any
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -172,3 +173,28 @@ def write_dashboard_json(snapshot: Mapping[str, object], file_path: str | Path) 
 def load_dashboard_json(file_path: str | Path) -> dict[str, object]:
     path = Path(file_path)
     return json.loads(path.read_text())
+
+
+def extract_pending_service_scope(snapshot: Mapping[str, Any] | None) -> set[tuple[str, str]]:
+    if not isinstance(snapshot, Mapping):
+        return set()
+
+    scope: set[tuple[str, str]] = set()
+    projects = snapshot.get("projects")
+    if not isinstance(projects, Sequence):
+        return scope
+
+    for project in projects:
+        if not isinstance(project, Mapping):
+            continue
+        project_name = project.get("name")
+        services = project.get("services")
+        if not isinstance(project_name, str) or not isinstance(services, Sequence):
+            continue
+        for service in services:
+            if not isinstance(service, Mapping):
+                continue
+            service_name = service.get("service")
+            if isinstance(service_name, str) and service_name:
+                scope.add((project_name, service_name))
+    return scope

--- a/app/docker_client.py
+++ b/app/docker_client.py
@@ -39,6 +39,31 @@ def get_running_containers(
     return containers
 
 
+def get_containers_for_compose_services(
+    client: DockerClient,
+    scope: set[tuple[str, str]],
+) -> List[Container]:
+    containers_by_id: dict[str, Container] = {}
+    for project, service in scope:
+        matches = client.containers.list(
+            filters={
+                "status": "running",
+                "label": [
+                    f"com.docker.compose.project={project}",
+                    f"com.docker.compose.service={service}",
+                ],
+            }
+        )
+        for container in matches:
+            if container.labels.get("diun.enable") == "false":
+                continue
+            container_id = container.id
+            if not container_id:
+                continue
+            containers_by_id[container_id] = container
+    return list(containers_by_id.values())
+
+
 def extract_digest_from_repo_digests(
     repo_digests: list[str], image_name: str | None = None
 ) -> str | None:

--- a/app/main.py
+++ b/app/main.py
@@ -9,10 +9,16 @@ from loguru import logger
 from app.dashboard_snapshot import (
     build_dashboard_snapshot,
     canonical_image_name,
+    extract_pending_service_scope,
+    load_dashboard_json,
     write_dashboard_json,
 )
 from app.diun_client import DiunClientError, load_diun_latest, load_diun_manifests
-from app.docker_client import get_docker_client, get_running_containers
+from app.docker_client import (
+    get_containers_for_compose_services,
+    get_docker_client,
+    get_running_containers,
+)
 from app.yaml_helper import (
     compare_yaml_files,
     create_diun_yaml,
@@ -22,6 +28,13 @@ from app.yaml_helper import (
     merge_custom_metadata,
     write_yaml_to_file,
 )
+
+DEFAULT_MONITOR_ALL = os.getenv("WATCHBYDEFAULT", "false").lower() == "true"
+DEFAULT_COMPOSE_TRACK = os.getenv("DOCKER_COMPOSE_METADATA", "false").lower() == "true"
+DEFAULT_OUTPUT_PATH = os.getenv("DIUN_YAML_PATH", "/config/config.yml")
+DEFAULT_DASHBOARD_JSON_PATH = os.getenv("DIUN_DASHBOARD_JSON_PATH", "/config/dashboard.json")
+DEFAULT_DIUN_CONTAINER_NAME = os.getenv("DIUN_CONTAINER_NAME", "diun")
+DEFAULT_DASHBOARD_CRON_SCHEDULE = os.getenv("DIUN_DASHBOARD_CRON_SCHEDULE", "7 */6 * * *")
 
 
 def setup_logging(level: str) -> None:
@@ -58,6 +71,98 @@ def build_manifest_lookup(
     return lookup
 
 
+def build_snapshot_from_entries(
+    entries: list[dict],
+    diun_container_name: str,
+) -> dict[str, object]:
+    client = get_docker_client()
+    latest_by_image = load_diun_latest(client, diun_container_name)
+    manifest_lookup = build_manifest_lookup(
+        client,
+        diun_container_name,
+        entries,
+        latest_by_image,
+    )
+    entries = enrich_missing_current_digests(entries, manifest_lookup)
+    return build_dashboard_snapshot(
+        entries,
+        latest_by_image,
+        manifest_lookup=manifest_lookup,
+    )
+
+
+def filter_entries_for_scope(
+    entries: list[dict],
+    scope: set[tuple[str, str]],
+) -> list[dict]:
+    filtered: list[dict] = []
+    for entry in entries:
+        metadata = entry.get("metadata")
+        if not isinstance(metadata, dict):
+            continue
+        project = metadata.get("compose_project")
+        service = metadata.get("compose_service")
+        if isinstance(project, str) and isinstance(service, str) and (project, service) in scope:
+            filtered.append(entry)
+    return filtered
+
+
+def generate_dashboard_snapshot(
+    output_path: str,
+    m_all: bool,
+    compose_track: bool,
+    diun_container_name: str,
+    *,
+    persist_yaml: bool = True,
+) -> dict[str, object]:
+    client = get_docker_client()
+    containers = get_running_containers(client, m_all)
+    existing_entries = load_yaml_entries(output_path)
+    diun_entries = create_diun_yaml(containers, m_all, compose_track)
+    diun_entries = merge_custom_metadata(diun_entries, existing_entries)
+
+    if persist_yaml and compare_yaml_files(output_path, diun_entries):
+        write_yaml_to_file(diun_entries, output_path)
+
+    return build_snapshot_from_entries(diun_entries, diun_container_name)
+
+
+def generate_dashboard_snapshot_from_yaml(
+    output_path: str,
+    diun_container_name: str,
+) -> dict[str, object]:
+    return build_snapshot_from_entries(load_yaml_entries(output_path), diun_container_name)
+
+
+def generate_targeted_dashboard_snapshot(
+    output_path: str,
+    dashboard_json_path: str,
+    *,
+    compose_track: bool,
+    diun_container_name: str,
+) -> dict[str, object]:
+    try:
+        current_snapshot = load_dashboard_json(dashboard_json_path)
+        scope = extract_pending_service_scope(current_snapshot)
+    except FileNotFoundError:
+        current_snapshot = None
+        scope = set()
+
+    if current_snapshot is not None and not scope:
+        return current_snapshot
+
+    if not scope:
+        return generate_dashboard_snapshot_from_yaml(output_path, diun_container_name)
+
+    existing_entries = load_yaml_entries(output_path)
+    client = get_docker_client()
+    containers = get_containers_for_compose_services(client, scope)
+    scoped_existing_entries = filter_entries_for_scope(existing_entries, scope)
+    diun_entries = create_diun_yaml(containers, True, compose_track)
+    diun_entries = merge_custom_metadata(diun_entries, scoped_existing_entries)
+    return build_snapshot_from_entries(diun_entries, diun_container_name)
+
+
 def run_tasks(
     output_path: str,
     dashboard_json_path: str,
@@ -65,28 +170,40 @@ def run_tasks(
     compose_track: bool,
     diun_container_name: str,
 ) -> None:
+    snapshot = generate_dashboard_snapshot(
+        output_path,
+        m_all,
+        compose_track,
+        diun_container_name,
+    )
+    changed = write_dashboard_json(snapshot, dashboard_json_path)
+    if changed:
+        logger.info(f"📊 Dashboard snapshot written to {dashboard_json_path}")
+    else:
+        logger.info(f"📊 Dashboard snapshot is unchanged at {dashboard_json_path}")
+
+
+def run_config_only(
+    output_path: str,
+    m_all: bool,
+    compose_track: bool,
+) -> None:
     client = get_docker_client()
     containers = get_running_containers(client, m_all)
     existing_entries = load_yaml_entries(output_path)
     diun_entries = create_diun_yaml(containers, m_all, compose_track)
     diun_entries = merge_custom_metadata(diun_entries, existing_entries)
 
-    latest_by_image = load_diun_latest(client, diun_container_name)
-    manifest_lookup = build_manifest_lookup(
-        client,
-        diun_container_name,
-        diun_entries,
-        latest_by_image,
-    )
-    diun_entries = enrich_missing_current_digests(diun_entries, manifest_lookup)
     if compare_yaml_files(output_path, diun_entries):
         write_yaml_to_file(diun_entries, output_path)
 
-    snapshot = build_dashboard_snapshot(
-        diun_entries,
-        latest_by_image,
-        manifest_lookup=manifest_lookup,
-    )
+
+def run_dashboard_only(
+    output_path: str,
+    dashboard_json_path: str,
+    diun_container_name: str,
+) -> None:
+    snapshot = generate_dashboard_snapshot_from_yaml(output_path, diun_container_name)
     changed = write_dashboard_json(snapshot, dashboard_json_path)
     if changed:
         logger.info(f"📊 Dashboard snapshot written to {dashboard_json_path}")
@@ -101,16 +218,26 @@ def main():
         action="store_true",
         help="Indicates this is the first manual run after container start.",
     )
+    parser.add_argument(
+        "--config-only",
+        action="store_true",
+        help="Refresh only the generated DIUN config.yml file.",
+    )
+    parser.add_argument(
+        "--dashboard-only",
+        action="store_true",
+        help="Refresh only dashboard.json from the saved config.yml and DIUN state.",
+    )
     args = parser.parse_args()
 
     logging_level = os.getenv("LOG_LEVEL", "INFO")
     setup_logging(logging_level)
 
-    monitor_all = os.getenv("WATCHBYDEFAULT", "false").lower() == "true"
-    compose_track = os.getenv("DOCKER_COMPOSE_METADATA", "false").lower() == "true"
-    output_path = os.getenv("DIUN_YAML_PATH", "/config/config.yml")
-    dashboard_json_path = os.getenv("DIUN_DASHBOARD_JSON_PATH", "/config/dashboard.json")
-    diun_container_name = os.getenv("DIUN_CONTAINER_NAME", "diun")
+    monitor_all = DEFAULT_MONITOR_ALL
+    compose_track = DEFAULT_COMPOSE_TRACK
+    output_path = DEFAULT_OUTPUT_PATH
+    dashboard_json_path = DEFAULT_DASHBOARD_JSON_PATH
+    diun_container_name = DEFAULT_DIUN_CONTAINER_NAME
 
     if monitor_all:
         logger.info("🐳 Monitoring all containers by default...")
@@ -121,22 +248,40 @@ def main():
         logger.info("🐳 Tracking Docker Compose metadata...")
 
     logger.info(f"📊 Dashboard snapshot path: {dashboard_json_path}")
+    logger.info(f"🕒 Dashboard cron schedule: {DEFAULT_DASHBOARD_CRON_SCHEDULE}")
     logger.info(f"🐳 DIUN container: {diun_container_name}")
 
     if args.first_run:
         logger.info("✨ Running initial setup...")
         create_empty_yaml(output_path)
+    elif args.dashboard_only:
+        logger.info("📊 Running dashboard-only refresh...")
+    elif args.config_only:
+        logger.info("📄 Running config-only refresh...")
     else:
-        logger.info("⏰ Running scheduled cron job...")
+        logger.info("⏰ Running combined refresh...")
 
     try:
-        run_tasks(
-            output_path,
-            dashboard_json_path,
-            monitor_all,
-            compose_track,
-            diun_container_name,
-        )
+        if args.dashboard_only:
+            run_dashboard_only(
+                output_path,
+                dashboard_json_path,
+                diun_container_name,
+            )
+        elif args.config_only:
+            run_config_only(
+                output_path,
+                monitor_all,
+                compose_track,
+            )
+        else:
+            run_tasks(
+                output_path,
+                dashboard_json_path,
+                monitor_all,
+                compose_track,
+                diun_container_name,
+            )
     except DiunClientError as exc:
         logger.error(f"Failed to refresh DIUN dashboard data: {exc}")
         raise SystemExit(1) from exc

--- a/app/static/app.js
+++ b/app/static/app.js
@@ -52,14 +52,17 @@ function renderServiceRow(service) {
 }
 
 function renderProject(project) {
-  const rows = project.services.map(renderServiceRow).join("");
+  const services = Array.isArray(project.services) ? project.services : [];
+  const rows = services.map(renderServiceRow).join("");
+  const serviceCount = project.service_count ?? services.length;
   return `
     <section class="panel project-panel">
       <div class="project-header">
         <div>
           <h2>${escapeHtml(project.name)}</h2>
-          <p class="subtle">${project.services.length} impacted service(s)</p>
+          <p class="subtle">${escapeHtml(serviceCount)} impacted service(s)</p>
         </div>
+        <span class="project-chip">Project</span>
       </div>
       <div class="table-wrap">
         <table>
@@ -84,10 +87,26 @@ function renderDashboard(data) {
 
   const summaryHtml = `
     <section class="summary-grid">
-      <article class="summary-card"><span class="summary-label">Projects</span><strong>${summary.projects ?? 0}</strong></article>
-      <article class="summary-card"><span class="summary-label">Services</span><strong>${summary.services ?? 0}</strong></article>
-      <article class="summary-card"><span class="summary-label">Tag bumps</span><strong>${summary.tag_bumps ?? 0}</strong></article>
-      <article class="summary-card"><span class="summary-label">Digest refreshes</span><strong>${summary.digest_refreshes ?? 0}</strong></article>
+      <article class="summary-card summary-card-projects">
+        <span class="summary-label">Projects</span>
+        <strong>${summary.projects ?? 0}</strong>
+        <span class="summary-footnote">Stacks with pending activity</span>
+      </article>
+      <article class="summary-card summary-card-services">
+        <span class="summary-label">Services</span>
+        <strong>${summary.services ?? 0}</strong>
+        <span class="summary-footnote">Individual containers to review</span>
+      </article>
+      <article class="summary-card summary-card-bumps">
+        <span class="summary-label">Tag bumps</span>
+        <strong>${summary.tag_bumps ?? 0}</strong>
+        <span class="summary-footnote">Version changes available</span>
+      </article>
+      <article class="summary-card summary-card-digests">
+        <span class="summary-label">Digest refreshes</span>
+        <strong>${summary.digest_refreshes ?? 0}</strong>
+        <span class="summary-footnote">Same tag, new image digest</span>
+      </article>
     </section>
     <section class="panel meta-panel">
       <span id="generated-at-label" data-generated-at="${escapeHtml(data.generated_at || "")}">${escapeHtml(getRelativeTimestampText(data.generated_at))}</span>
@@ -134,7 +153,8 @@ async function refreshDashboard() {
   status.textContent = "Refreshing data…";
 
   try {
-    const response = await fetch("/api/report", {
+    const response = await fetch("/api/report/refresh", {
+      method: "POST",
       headers: { Accept: "application/json" },
       cache: "no-store",
     });

--- a/app/web.py
+++ b/app/web.py
@@ -8,7 +8,14 @@ from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
-from app.dashboard_snapshot import load_dashboard_json
+from app.dashboard_snapshot import load_dashboard_json, write_dashboard_json
+from app.diun_client import DiunClientError
+from app.main import (
+    DEFAULT_COMPOSE_TRACK,
+    DEFAULT_DIUN_CONTAINER_NAME,
+    DEFAULT_OUTPUT_PATH,
+    generate_targeted_dashboard_snapshot,
+)
 
 APP_NAME = os.getenv("DIUN_DASHBOARD_APP_NAME", "DIUN Dashboard")
 DASHBOARD_JSON_PATH = Path(os.getenv("DIUN_DASHBOARD_JSON_PATH", "/config/dashboard.json"))
@@ -27,6 +34,22 @@ def read_dashboard_snapshot() -> dict[str, object]:
         return load_dashboard_json(DASHBOARD_JSON_PATH)
     except FileNotFoundError as exc:
         raise DashboardLoadError(f"Dashboard snapshot not found: {DASHBOARD_JSON_PATH}") from exc
+    except Exception as exc:  # pragma: no cover - defensive runtime guard
+        raise DashboardLoadError(str(exc)) from exc
+
+
+def refresh_dashboard_snapshot() -> dict[str, object]:
+    try:
+        snapshot = generate_targeted_dashboard_snapshot(
+            DEFAULT_OUTPUT_PATH,
+            str(DASHBOARD_JSON_PATH),
+            compose_track=DEFAULT_COMPOSE_TRACK,
+            diun_container_name=DEFAULT_DIUN_CONTAINER_NAME,
+        )
+        write_dashboard_json(snapshot, DASHBOARD_JSON_PATH)
+        return snapshot
+    except DiunClientError as exc:
+        raise DashboardLoadError(str(exc)) from exc
     except Exception as exc:  # pragma: no cover - defensive runtime guard
         raise DashboardLoadError(str(exc)) from exc
 
@@ -65,5 +88,16 @@ def api_report() -> JSONResponse:
     except DashboardLoadError as exc:
         return JSONResponse(
             {"message": "Unable to load pending updates", "details": str(exc)},
+            status_code=502,
+        )
+
+
+@app.post("/api/report/refresh")
+def api_report_refresh() -> JSONResponse:
+    try:
+        return JSONResponse(refresh_dashboard_snapshot())
+    except DashboardLoadError as exc:
+        return JSONResponse(
+            {"message": "Unable to refresh pending updates", "details": str(exc)},
             status_code=502,
         )

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -5,9 +5,11 @@ set -e
 trap 'echo "Received SIGTERM, stopping cron..."; pkill cron || true; exit 0' TERM INT
 
 export CRON_SANTIZED=$(echo "${CRON_SCHEDULE:-0 */6 * * *}" | tr -d '"'\''')
+export DASHBOARD_CRON_SANTIZED=$(echo "${DIUN_DASHBOARD_CRON_SCHEDULE:-7 */6 * * *}" | tr -d '"'\''')
 {
     echo "export DIUN_YAML_PATH=\"${DIUN_YAML_PATH:-/config/config.yml}\""
     echo "export DIUN_DASHBOARD_JSON_PATH=\"${DIUN_DASHBOARD_JSON_PATH:-/config/dashboard.json}\""
+    echo "export DIUN_DASHBOARD_CRON_SCHEDULE=\"${DIUN_DASHBOARD_CRON_SCHEDULE:-7 */6 * * *}\""
     echo "export DIUN_CONTAINER_NAME=\"${DIUN_CONTAINER_NAME:-diun}\""
     echo "export LOG_LEVEL=\"${LOG_LEVEL:-INFO}\""
     echo "export WATCHBYDEFAULT=\"${WATCHBYDEFAULT:-false}\""
@@ -17,14 +19,15 @@ export CRON_SANTIZED=$(echo "${CRON_SCHEDULE:-0 */6 * * *}" | tr -d '"'\''')
 } > /etc/cron.d/env-vars
 
 {
-    echo "${CRON_SANTIZED} root /bin/sh -c '. /etc/cron.d/env-vars && /usr/local/bin/python /app/app/main.py >> /proc/1/fd/1 2>&1'"
+    echo "${CRON_SANTIZED} root /bin/sh -c '. /etc/cron.d/env-vars && /usr/local/bin/python /app/app/main.py --config-only >> /proc/1/fd/1 2>&1'"
+    echo "${DASHBOARD_CRON_SANTIZED} root /bin/sh -c '. /etc/cron.d/env-vars && /usr/local/bin/python /app/app/main.py --dashboard-only >> /proc/1/fd/1 2>&1'"
 } > /etc/cron.d/diunboost
 
 chmod 0644 /etc/cron.d/env-vars /etc/cron.d/diunboost
 crontab /etc/cron.d/diunboost
 
 . /etc/cron.d/env-vars
-/usr/local/bin/python /app/app/main.py --first-run
+/usr/local/bin/python /app/app/main.py --first-run --config-only
 
 cron
 exec uvicorn app.web:app --host "${DIUN_DASHBOARD_BIND_HOST:-0.0.0.0}" --port "${DIUN_DASHBOARD_BIND_PORT:-8000}"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,148 @@
+from app import main
+
+
+def test_generate_dashboard_snapshot_from_yaml_uses_saved_config(monkeypatch):
+    entries = [
+        {
+            "name": "linuxserver/sonarr:4.0.17",
+            "metadata": {
+                "compose_project": "arr-stack",
+                "compose_service": "sonarr",
+                "current_tag": "4.0.17",
+            },
+        }
+    ]
+    latest_by_image = {
+        "linuxserver/sonarr": {
+            "latest": {"tag": "4.0.18", "digest": "sha256:new"}
+        }
+    }
+    manifest_lookup = {"linuxserver/sonarr": [{"tag": "4.0.18", "digest": "sha256:new"}]}
+    expected_snapshot = {"generated_at": "2026-06-11T00:00:00+00:00", "projects": [], "summary": {}}
+
+    monkeypatch.setattr(main, "load_yaml_entries", lambda path: entries)
+    monkeypatch.setattr(main, "get_docker_client", lambda: object())
+    monkeypatch.setattr(main, "load_diun_latest", lambda client, container_name: latest_by_image)
+    monkeypatch.setattr(
+        main,
+        "build_manifest_lookup",
+        lambda client, container_name, source_entries, latest: manifest_lookup,
+    )
+    monkeypatch.setattr(
+        main,
+        "build_dashboard_snapshot",
+        lambda source_entries, latest, manifest_lookup=None: expected_snapshot,
+    )
+
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("should not scan running containers for dashboard-only refresh")
+
+    monkeypatch.setattr(main, "get_running_containers", fail_if_called)
+
+    snapshot = main.generate_dashboard_snapshot_from_yaml("/tmp/config.yml", "diun")
+
+    assert snapshot == expected_snapshot
+
+
+def test_generate_targeted_dashboard_snapshot_filters_to_pending_services(monkeypatch):
+    existing_entries = [
+        {
+            "name": "linuxserver/sonarr:4.0.17",
+            "metadata": {
+                "compose_project": "arr-stack",
+                "compose_service": "sonarr",
+                "current_tag": "4.0.17",
+            },
+        },
+        {
+            "name": "linuxserver/radarr:6.1.1",
+            "metadata": {
+                "compose_project": "arr-stack",
+                "compose_service": "radarr",
+                "current_tag": "6.1.1",
+            },
+        },
+    ]
+    dashboard_snapshot = {
+        "projects": [
+            {
+                "name": "arr-stack",
+                "services": [
+                    {"service": "sonarr", "current": "4.0.17", "latest": "4.0.18"}
+                ],
+            }
+        ]
+    }
+    live_entries = [
+        {
+            "name": "linuxserver/sonarr:4.0.18",
+            "metadata": {
+                "compose_project": "arr-stack",
+                "compose_service": "sonarr",
+                "current_tag": "4.0.18",
+            },
+        }
+    ]
+    expected_snapshot = {"generated_at": "2026-06-11T00:07:00+00:00", "projects": [], "summary": {}}
+
+    monkeypatch.setattr(main, "load_yaml_entries", lambda path: existing_entries)
+    monkeypatch.setattr(main, "load_dashboard_json", lambda path: dashboard_snapshot)
+    monkeypatch.setattr(main, "get_docker_client", lambda: object())
+    monkeypatch.setattr(
+        main,
+        "get_containers_for_compose_services",
+        lambda client, scope: ["sonarr-container"],
+    )
+    monkeypatch.setattr(
+        main,
+        "create_diun_yaml",
+        lambda containers, m_all, compose_track: live_entries,
+    )
+    monkeypatch.setattr(main, "merge_custom_metadata", lambda entries, existing: entries)
+    monkeypatch.setattr(main, "load_diun_latest", lambda client, container_name: {})
+    monkeypatch.setattr(main, "build_manifest_lookup", lambda *args, **kwargs: {})
+    monkeypatch.setattr(
+        main,
+        "build_dashboard_snapshot",
+        lambda source_entries, latest, manifest_lookup=None: expected_snapshot,
+    )
+
+    snapshot = main.generate_targeted_dashboard_snapshot(
+        "/tmp/config.yml",
+        "/tmp/dashboard.json",
+        compose_track=True,
+        diun_container_name="diun",
+    )
+
+    assert snapshot == expected_snapshot
+
+
+def test_generate_targeted_dashboard_snapshot_returns_existing_empty_snapshot(monkeypatch):
+    empty_snapshot = {
+        "generated_at": "2026-06-11T00:10:00+00:00",
+        "projects": [],
+        "summary": {
+            "projects": 0,
+            "services": 0,
+            "tag_bumps": 0,
+            "digest_refreshes": 0,
+        },
+    }
+
+    monkeypatch.setattr(main, "load_dashboard_json", lambda path: empty_snapshot)
+
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("empty snapshot refresh should not call Docker or DIUN")
+
+    monkeypatch.setattr(main, "load_yaml_entries", fail_if_called)
+    monkeypatch.setattr(main, "generate_dashboard_snapshot_from_yaml", fail_if_called)
+    monkeypatch.setattr(main, "get_docker_client", fail_if_called)
+
+    snapshot = main.generate_targeted_dashboard_snapshot(
+        "/tmp/config.yml",
+        "/tmp/dashboard.json",
+        compose_track=True,
+        diun_container_name="diun",
+    )
+
+    assert snapshot == empty_snapshot

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -27,6 +27,27 @@ def test_api_report_reads_dashboard_snapshot(tmp_path, monkeypatch):
     assert response.json() == snapshot
 
 
+def test_api_report_refresh_generates_live_snapshot(monkeypatch):
+    snapshot = {
+        "generated_at": "2026-06-10T17:05:00+00:00",
+        "projects": [{"name": "arr-stack", "services": []}],
+        "summary": {
+            "projects": 1,
+            "services": 0,
+            "tag_bumps": 0,
+            "digest_refreshes": 0,
+        },
+    }
+
+    monkeypatch.setattr(web, "refresh_dashboard_snapshot", lambda: snapshot)
+
+    client = TestClient(web.app)
+    response = client.post("/api/report/refresh")
+
+    assert response.status_code == 200
+    assert response.json() == snapshot
+
+
 def test_healthz_returns_app_name():
     client = TestClient(web.app)
     response = client.get("/healthz")


### PR DESCRIPTION
- Added a new API endpoint to refresh the dashboard snapshot with live data.
- Introduced functions to extract pending service scopes and filter entries for the dashboard.
- Enhanced the dashboard rendering logic to display service counts and additional metadata.
- Updated the entrypoint script to handle separate cron jobs for config and dashboard refreshes.
- Improved the main application logic to support targeted refresh operations.
- Added tests for the new dashboard refresh functionality and ensured existing tests cover new behaviors.