### PR TITLE
Fix dashboard digest refresh detection and add release notes links

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Recent changes added a proper dashboard-oriented workflow:
 - dashboard filtering now respects generated `include_tags` rules
 - dashboard downgrade protection skips latest tags that are numerically older than the current tag
 - preserved custom metadata on YAML regeneration
+- optional manually configured release-notes links in the dashboard
 - initial startup now creates the YAML file only if it does not already exist
 
 ## Features
@@ -93,8 +94,39 @@ You can add your own keys under `metadata` in generated DIUN entries. diun-boost
 
 - `current_tag`
 - `current_digest`
+- `current_repo_digests`
 - `compose_project`
 - `compose_service`
+
+Because `release_notes_url` is not auto-managed, it is treated as custom metadata and is preserved across config regeneration.
+
+### Manually configured release-notes links
+
+You can manually add `metadata.release_notes_url` to an entry in `/config/config.yml` to show a release-notes link for that service in the dashboard. The URL is preserved across config regeneration because it is custom metadata.
+
+The dashboard shows a `Release notes ↗` link only when `release_notes_url` is configured and starts with `http://` or `https://`. If `release_notes_url` is missing, invalid, or empty, no release-notes link, placeholder, disabled link, or extra text is displayed.
+
+This feature does not auto-discover changelogs or release notes, call the GitHub API, scrape websites, or substitute template variables. It is manually configured and static.
+
+Example:
+
+```yaml
+- name: redis:8.8.0
+  notify_on:
+    - new
+    - update
+  metadata:
+    current_tag: 8.8.0
+    current_digest: sha256:...
+    current_repo_digests:
+      - sha256:...
+    compose_project: paperless
+    compose_service: paperless-redis
+    release_notes_url: https://github.com/redis/redis/releases
+  watch_repo: true
+  include_tags:
+    - ^8\.8\..+$
+```
 
 ### Dashboard for pending updates
 
@@ -104,6 +136,7 @@ The dashboard snapshot groups updates by Compose project and shows:
 - update type (`tag_bump` or `digest_refresh`)
 - current tag
 - latest tag
+- optional `Release notes ↗` link when `metadata.release_notes_url` is configured
 - summary counts for projects, services, tag bumps, and digest refreshes
 
 Dashboard candidate selection follows the same generated `include_tags` rules used by DIUN. This prevents the dashboard from showing an update candidate that DIUN itself would not watch. It also skips numeric downgrades, so a registry-reported `4.0.0` latest tag will not be reported as pending when the running container is already on `4.0.1`.
@@ -265,8 +298,11 @@ providers:
   metadata:
     current_tag: 4.0.17
     current_digest: sha256:...
+    current_repo_digests:
+      - sha256:...
     compose_project: arr-stack
     compose_service: sonarr
+    release_notes_url: https://github.com/linuxserver/docker-sonarr/releases
     team: media
     severity: normal
   watch_repo: true
@@ -274,7 +310,7 @@ providers:
     - ^((?:5|[6-9]\d*)\.\d+\.\d+|4\.(?:1|[2-9]\d*)\.\d+|4.0\.(?:17|[1-9]\d*))$
 ```
 
-User-defined metadata like `team` and `severity` is preserved across future regenerations.
+User-defined metadata like `team`, `severity`, and `release_notes_url` is preserved across future regenerations.
 
 ## Dashboard API
 
@@ -291,7 +327,7 @@ User-defined metadata like `team` and `severity` is preserved across future rege
 - When `WATCHBYDEFAULT=true`, all running containers are included except explicit opt-outs.
 - The dashboard distinguishes between:
   - `tag_bump`: current tag differs from latest tag
-  - `digest_refresh`: tag is unchanged but image digest changed
+  - `digest_refresh`: tag is unchanged and DIUN's latest registry digest is not present in Docker's current repo digests
 - `dashboard.json` is only rewritten when content changes.
 - `config.yml` is only rewritten when content changes.
 - If `dashboard.json` already shows no pending services, the targeted refresh path returns that snapshot as-is.

--- a/app/dashboard_snapshot.py
+++ b/app/dashboard_snapshot.py
@@ -88,6 +88,13 @@ def build_dashboard_snapshot(
         service = metadata.get("compose_service")
         current_tag = metadata.get("current_tag")
         current_digest = metadata.get("current_digest")
+        raw_current_repo_digests = metadata.get("current_repo_digests")
+        current_repo_digests = (
+            [digest for digest in raw_current_repo_digests if isinstance(digest, str) and digest]
+            if isinstance(raw_current_repo_digests, Sequence)
+            and not isinstance(raw_current_repo_digests, (str, bytes))
+            else []
+        )
         full_image = entry.get("name")
         if not all(isinstance(value, str) and value for value in [project, service, current_tag, full_image]):
             continue
@@ -132,6 +139,8 @@ def build_dashboard_snapshot(
         if current_tag != latest_tag:
             update_type = "tag_bump"
             tag_bumps += 1
+        elif latest_digest in current_repo_digests:
+            continue
         elif isinstance(current_digest, str) and current_digest and current_digest != latest_digest:
             update_type = "digest_refresh"
             digest_refreshes += 1

--- a/app/dashboard_snapshot.py
+++ b/app/dashboard_snapshot.py
@@ -32,6 +32,10 @@ def matches_include_tags(tag: str, include_tags: Sequence[str] | None) -> bool:
     return not patterns or any(pattern.match(tag) for pattern in patterns)
 
 
+def is_valid_release_notes_url(value: object) -> bool:
+    return isinstance(value, str) and value.startswith(("http://", "https://"))
+
+
 def select_latest_manifest(
     image_name: str,
     include_tags: Sequence[str] | None,
@@ -88,6 +92,7 @@ def build_dashboard_snapshot(
         service = metadata.get("compose_service")
         current_tag = metadata.get("current_tag")
         current_digest = metadata.get("current_digest")
+        release_notes_url = metadata.get("release_notes_url")
         raw_current_repo_digests = metadata.get("current_repo_digests")
         current_repo_digests = (
             [digest for digest in raw_current_repo_digests if isinstance(digest, str) and digest]
@@ -147,14 +152,16 @@ def build_dashboard_snapshot(
         else:
             continue
 
-        grouped[project].append(
-            {
-                "service": service,
-                "update_type": update_type,
-                "current": current_tag,
-                "latest": latest_tag,
-            }
-        )
+        service_item = {
+            "service": service,
+            "update_type": update_type,
+            "current": current_tag,
+            "latest": latest_tag,
+        }
+        if is_valid_release_notes_url(release_notes_url):
+            service_item["release_notes_url"] = release_notes_url
+
+        grouped[project].append(service_item)
 
     projects = [
         {"name": project, "services": sorted(services, key=lambda item: item["service"])}

--- a/app/docker_client.py
+++ b/app/docker_client.py
@@ -82,10 +82,51 @@ def extract_digest_from_repo_digests(
     return None
 
 
+def canonical_repo_name(name: str) -> str:
+    name = name.removeprefix("docker.io/")
+    if "/" not in name:
+        return f"library/{name}"
+    return name
+
+
+def get_container_repo_digests(container: Container) -> list[str]:
+    """Return all registry manifest/index digests Docker has for an image.
+
+    Docker image IDs are local config digests and are intentionally not used here.
+    RepoDigests are registry digests in the same sha256:<hex> form reported by DIUN.
+    """
+    image_names = []
+    for image_tag in container.image.tags or []:
+        if ":" not in image_tag:
+            continue
+        image_names.append(canonical_repo_name(image_tag.rsplit(":", 1)[0]))
+    image_name_set = set(image_names)
+
+    matching_digests: list[str] = []
+    fallback_digests: list[str] = []
+    seen_matching: set[str] = set()
+    seen_fallback: set[str] = set()
+
+    for repo_digest in container.image.attrs.get("RepoDigests", []) or []:
+        if not isinstance(repo_digest, str) or "@" not in repo_digest:
+            continue
+        repo_name, digest = repo_digest.split("@", 1)
+        if not digest:
+            continue
+        canonical_name = canonical_repo_name(repo_name)
+        if not image_name_set or canonical_name in image_name_set:
+            if digest not in seen_matching:
+                matching_digests.append(digest)
+                seen_matching.add(digest)
+        elif digest not in seen_fallback:
+            fallback_digests.append(digest)
+            seen_fallback.add(digest)
+
+    if matching_digests:
+        return matching_digests
+    return fallback_digests
+
+
 def get_container_current_digest(container: Container) -> str | None:
-    image_name = None
-    image_tags = container.image.tags or []
-    if image_tags:
-        image_name = image_tags[0].rsplit(":", 1)[0]
-    repo_digests = container.image.attrs.get("RepoDigests", [])
-    return extract_digest_from_repo_digests(repo_digests, image_name=image_name)
+    repo_digests = get_container_repo_digests(container)
+    return repo_digests[0] if repo_digests else None

--- a/app/static/app.js
+++ b/app/static/app.js
@@ -55,9 +55,27 @@ function updateRefreshStatus(value) {
 }
 
 function renderServiceRow(service) {
+  const serviceName = escapeHtml(service.service);
+  const releaseNotesLink = typeof service.release_notes_url === "string" && service.release_notes_url
+    ? `<a class="release-notes-icon-link" href="${escapeHtml(service.release_notes_url)}" target="_blank" rel="noopener noreferrer" title="Release notes" aria-label="Release notes for ${serviceName}">
+        <svg class="release-notes-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
+          <path d="M14 2v6h6"/>
+          <path d="M16 13H8"/>
+          <path d="M16 17H8"/>
+          <path d="M10 9H8"/>
+        </svg>
+      </a>`
+    : "";
+
   return `
     <tr>
-      <td class="service-name">${escapeHtml(service.service)}</td>
+      <td class="service-name">
+        <div class="service-title-row">
+          <span class="service-title">${serviceName}</span>
+          ${releaseNotesLink}
+        </div>
+      </td>
       <td><span class="badge badge-${escapeHtml(service.update_type.replaceAll("_", "-"))}">${escapeHtml(service.update_type)}</span></td>
       <td><code>${escapeHtml(service.current)}</code></td>
       <td><code>${escapeHtml(service.latest)}</code></td>

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -327,9 +327,55 @@ td {
 }
 
 td.service-name {
-  font-weight: 600;
   color: var(--text);
   min-width: 180px;
+}
+
+.service-title-row {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  min-width: 0;
+}
+
+.service-title {
+  font-weight: 700;
+}
+
+.release-notes-icon-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.45rem;
+  height: 1.45rem;
+  border-radius: 999px;
+  color: rgba(199, 210, 254, 0.86);
+  background: rgba(99, 102, 241, 0.10);
+  border: 1px solid rgba(165, 180, 252, 0.22);
+  text-decoration: none;
+  transition:
+    color 120ms ease,
+    background 120ms ease,
+    border-color 120ms ease,
+    transform 120ms ease;
+}
+
+.release-notes-icon-link:hover {
+  color: #eef2ff;
+  background: rgba(99, 102, 241, 0.20);
+  border-color: rgba(199, 210, 254, 0.50);
+  transform: translateY(-1px);
+  text-decoration: none;
+}
+
+.release-notes-icon-link:focus-visible {
+  outline: 2px solid rgba(199, 210, 254, 0.65);
+  outline-offset: 2px;
+}
+
+.release-notes-icon {
+  width: 0.9rem;
+  height: 0.9rem;
 }
 
 th {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -71,7 +71,7 @@
     <div class="project-header">
       <div>
         <h2>{{ project.name }}</h2>
-        <p class="subtle">{{ project.service_count }} impacted service(s)</p>
+        <p class="subtle">{{ project.services | length }} impacted service(s)</p>
       </div>
       <span class="project-chip">Project</span>
     </div>
@@ -89,7 +89,39 @@
         <tbody>
           {% for service in project.services %}
           <tr>
-            <td class="service-name">{{ service.service }}</td>
+            <td class="service-name">
+              <div class="service-title-row">
+                <span class="service-title">{{ service.service }}</span>
+                {% if service.release_notes_url %}
+                <a
+                  class="release-notes-icon-link"
+                  href="{{ service.release_notes_url }}"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  title="Release notes"
+                  aria-label="Release notes for {{ service.service }}"
+                >
+                  <svg
+                    class="release-notes-icon"
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    aria-hidden="true"
+                  >
+                    <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
+                    <path d="M14 2v6h6"/>
+                    <path d="M16 13H8"/>
+                    <path d="M16 17H8"/>
+                    <path d="M10 9H8"/>
+                  </svg>
+                </a>
+                {% endif %}
+              </div>
+            </td>
             <td>
               <span class="badge badge-{{ service.update_type.replace('_', '-') }}">{{ service.update_type }}</span>
             </td>

--- a/app/yaml_helper.py
+++ b/app/yaml_helper.py
@@ -5,12 +5,13 @@ from docker.models.containers import Container
 from loguru import logger
 
 from app.dashboard_snapshot import canonical_image_name
-from app.docker_client import get_container_current_digest
+from app.docker_client import get_container_current_digest, get_container_repo_digests
 from app.regex_helper import build_tag_regex
 
 AUTO_METADATA_KEYS = {
     "current_tag",
     "current_digest",
+    "current_repo_digests",
     "compose_project",
     "compose_service",
 }
@@ -52,10 +53,13 @@ def create_diun_yaml(
                 continue
 
         image_name, tag = image.rsplit(":", 1)
+        current_repo_digests = get_container_repo_digests(container)
         current_digest = get_container_current_digest(container) or digest
         metadata = {"current_tag": tag}
         if current_digest:
             metadata["current_digest"] = current_digest
+        if current_repo_digests:
+            metadata["current_repo_digests"] = current_repo_digests
         entry = {"name": image, "notify_on": ["update"], "metadata": metadata}
 
         if "com.docker.compose.project" in container.labels and compose_track:
@@ -196,10 +200,11 @@ def enrich_missing_current_digests(
         for manifest in manifests:
             if manifest.get("tag") != current_tag:
                 continue
+            if metadata.get("current_digest"):
+                break
             digest = manifest.get("digest")
             if isinstance(digest, str) and digest:
-                if metadata.get("current_digest") != digest:
-                    metadata["current_digest"] = digest
+                metadata["current_digest"] = digest
                 break
     return entries
 

--- a/tests/test_dashboard_snapshot.py
+++ b/tests/test_dashboard_snapshot.py
@@ -105,6 +105,106 @@ def test_build_dashboard_snapshot_skips_entries_without_pending_updates():
     assert snapshot["projects"] == []
 
 
+
+def test_build_dashboard_snapshot_skips_digest_refresh_when_latest_is_in_repo_digests():
+    snapshot = build_dashboard_snapshot(
+        [
+            {
+                "name": "redis:8.8.0",
+                "metadata": {
+                    "compose_project": "paperless",
+                    "compose_service": "paperless-redis",
+                    "current_tag": "8.8.0",
+                    "current_digest": "sha256:027002f3",
+                    "current_repo_digests": ["sha256:027002f3", "sha256:2838d552"],
+                },
+            }
+        ],
+        {
+            "library/redis": {
+                "name": "library/redis",
+                "latest": {
+                    "tag": "8.8.0",
+                    "digest": "sha256:2838d552",
+                    "created": "2026-06-10T16:00:00Z",
+                },
+            }
+        },
+    )
+
+    assert snapshot["summary"]["digest_refreshes"] == 0
+    assert snapshot["projects"] == []
+
+
+def test_build_dashboard_snapshot_reports_digest_refresh_when_latest_missing_from_repo_digests():
+    snapshot = build_dashboard_snapshot(
+        [
+            {
+                "name": "redis:8.8.0",
+                "metadata": {
+                    "compose_project": "paperless",
+                    "compose_service": "paperless-redis",
+                    "current_tag": "8.8.0",
+                    "current_digest": "sha256:027002f3",
+                    "current_repo_digests": ["sha256:027002f3"],
+                },
+            }
+        ],
+        {
+            "library/redis": {
+                "name": "library/redis",
+                "latest": {
+                    "tag": "8.8.0",
+                    "digest": "sha256:2838d552",
+                    "created": "2026-06-10T16:00:00Z",
+                },
+            }
+        },
+    )
+
+    assert snapshot["summary"]["digest_refreshes"] == 1
+    assert snapshot["projects"] == [
+        {
+            "name": "paperless",
+            "services": [
+                {
+                    "service": "paperless-redis",
+                    "update_type": "digest_refresh",
+                    "current": "8.8.0",
+                    "latest": "8.8.0",
+                }
+            ],
+        }
+    ]
+
+
+def test_build_dashboard_snapshot_preserves_digest_compatibility_without_repo_digests():
+    snapshot = build_dashboard_snapshot(
+        [
+            {
+                "name": "redis:8.8.0",
+                "metadata": {
+                    "compose_project": "paperless",
+                    "compose_service": "paperless-redis",
+                    "current_tag": "8.8.0",
+                    "current_digest": "sha256:027002f3",
+                },
+            }
+        ],
+        {
+            "library/redis": {
+                "name": "library/redis",
+                "latest": {
+                    "tag": "8.8.0",
+                    "digest": "sha256:2838d552",
+                    "created": "2026-06-10T16:00:00Z",
+                },
+            }
+        },
+    )
+
+    assert snapshot["summary"]["digest_refreshes"] == 1
+
 def test_build_dashboard_snapshot_does_not_fall_back_to_latest_outside_include_tags():
     snapshot = build_dashboard_snapshot(
         [

--- a/tests/test_dashboard_snapshot.py
+++ b/tests/test_dashboard_snapshot.py
@@ -178,6 +178,103 @@ def test_build_dashboard_snapshot_reports_digest_refresh_when_latest_missing_fro
     ]
 
 
+def test_build_dashboard_snapshot_includes_valid_release_notes_url():
+    snapshot = build_dashboard_snapshot(
+        [
+            {
+                "name": "redis:8.8.0",
+                "metadata": {
+                    "compose_project": "paperless",
+                    "compose_service": "paperless-redis",
+                    "current_tag": "8.8.0",
+                    "current_digest": "sha256:027002f3",
+                    "release_notes_url": "https://github.com/redis/redis/releases",
+                },
+            }
+        ],
+        {
+            "library/redis": {
+                "name": "library/redis",
+                "latest": {
+                    "tag": "8.8.0",
+                    "digest": "sha256:2838d552",
+                    "created": "2026-06-10T16:00:00Z",
+                },
+            }
+        },
+    )
+
+    service = snapshot["projects"][0]["services"][0]
+    assert service["release_notes_url"] == "https://github.com/redis/redis/releases"
+
+
+def test_build_dashboard_snapshot_omits_release_notes_url_when_missing():
+    snapshot = build_dashboard_snapshot(
+        [
+            {
+                "name": "redis:8.8.0",
+                "metadata": {
+                    "compose_project": "paperless",
+                    "compose_service": "paperless-redis",
+                    "current_tag": "8.8.0",
+                    "current_digest": "sha256:027002f3",
+                },
+            }
+        ],
+        {
+            "library/redis": {
+                "name": "library/redis",
+                "latest": {
+                    "tag": "8.8.0",
+                    "digest": "sha256:2838d552",
+                    "created": "2026-06-10T16:00:00Z",
+                },
+            }
+        },
+    )
+
+    service = snapshot["projects"][0]["services"][0]
+    assert "release_notes_url" not in service
+
+
+def test_build_dashboard_snapshot_ignores_invalid_release_notes_url_values():
+    invalid_values = [
+        "github.com/redis/redis/releases",
+        "ftp://example.com/releases",
+        123,
+        None,
+    ]
+
+    for invalid_value in invalid_values:
+        snapshot = build_dashboard_snapshot(
+            [
+                {
+                    "name": "redis:8.8.0",
+                    "metadata": {
+                        "compose_project": "paperless",
+                        "compose_service": "paperless-redis",
+                        "current_tag": "8.8.0",
+                        "current_digest": "sha256:027002f3",
+                        "release_notes_url": invalid_value,
+                    },
+                }
+            ],
+            {
+                "library/redis": {
+                    "name": "library/redis",
+                    "latest": {
+                        "tag": "8.8.0",
+                        "digest": "sha256:2838d552",
+                        "created": "2026-06-10T16:00:00Z",
+                    },
+                }
+            },
+        )
+
+        service = snapshot["projects"][0]["services"][0]
+        assert "release_notes_url" not in service
+
+
 def test_build_dashboard_snapshot_preserves_digest_compatibility_without_repo_digests():
     snapshot = build_dashboard_snapshot(
         [

--- a/tests/test_frontend_rendering.py
+++ b/tests/test_frontend_rendering.py
@@ -18,3 +18,32 @@ def test_initial_status_uses_dashboard_generated_at_timestamp():
     assert 'id="refresh-status"' in template
     assert 'data-generated-at="{{ dashboard.generated_at }}"' in template
     assert 'updateRefreshStatus()' in script
+
+
+def test_template_release_notes_icon_link_is_conditional():
+    template = INDEX_TEMPLATE.read_text()
+
+    assert 'class="release-notes-icon-link"' in template
+    assert 'class="release-notes-icon"' in template
+    assert 'title="Release notes"' in template
+    assert 'aria-label="Release notes for {{ service.service }}"' in template
+    assert '{% if service.release_notes_url %}' in template
+    assert 'Release notes ↗' not in template
+
+
+def test_client_release_notes_icon_link_is_conditional():
+    script = APP_JS.read_text()
+
+    assert 'class="release-notes-icon-link"' in script
+    assert 'class="release-notes-icon"' in script
+    assert 'title="Release notes"' in script
+    assert 'aria-label="Release notes for ${serviceName}"' in script
+    assert 'Release notes ↗' not in script
+    assert ': ""' in script
+
+
+def test_template_uses_project_services_length_for_impacted_count():
+    template = INDEX_TEMPLATE.read_text()
+
+    assert '{{ project.services | length }} impacted service(s)' in template
+    assert '{{ project.service_count }} impacted service(s)' not in template

--- a/tests/test_yaml_helper.py
+++ b/tests/test_yaml_helper.py
@@ -49,6 +49,7 @@ def test_merge_custom_metadata_ignores_auto_keys():
             "compose_service": "web",
             "current_digest": "sha256:old",
             "current_repo_digests": ["sha256:old"],
+            "release_notes_url": "https://github.com/example/releases",
             "note": "keep",
         }}
     ]
@@ -59,6 +60,7 @@ def test_merge_custom_metadata_ignores_auto_keys():
     merged = merge_custom_metadata(generated, existing)
 
     assert merged[0]["metadata"]["current_tag"] == "1"
+    assert merged[0]["metadata"]["release_notes_url"] == "https://github.com/example/releases"
     assert merged[0]["metadata"]["note"] == "keep"
     assert "compose_project" not in merged[0]["metadata"]
     assert "compose_service" not in merged[0]["metadata"]

--- a/tests/test_yaml_helper.py
+++ b/tests/test_yaml_helper.py
@@ -48,6 +48,7 @@ def test_merge_custom_metadata_ignores_auto_keys():
             "compose_project": "app",
             "compose_service": "web",
             "current_digest": "sha256:old",
+            "current_repo_digests": ["sha256:old"],
             "note": "keep",
         }}
     ]
@@ -62,6 +63,7 @@ def test_merge_custom_metadata_ignores_auto_keys():
     assert "compose_project" not in merged[0]["metadata"]
     assert "compose_service" not in merged[0]["metadata"]
     assert "current_digest" not in merged[0]["metadata"]
+    assert "current_repo_digests" not in merged[0]["metadata"]
 
 
 def test_merge_custom_metadata_matches_by_name():
@@ -88,8 +90,29 @@ def test_create_diun_yaml_includes_current_digest_metadata():
 
     assert entries[0]["metadata"]["current_tag"] == "4.0.17"
     assert entries[0]["metadata"]["current_digest"] == "sha256:abcdef123456"
+    assert entries[0]["metadata"]["current_repo_digests"] == ["sha256:abcdef123456"]
     assert entries[0]["metadata"]["compose_project"] == "arr-stack"
     assert entries[0]["metadata"]["compose_service"] == "sonarr"
+
+
+def test_create_diun_yaml_includes_all_current_repo_digests():
+    container = make_container(
+        name="redis",
+        image_tag="redis:8.8.0",
+        repo_digests=[
+            "redis@sha256:027002f3",
+            "docker.io/library/redis@sha256:2838d552",
+            "library/redis@sha256:2838d552",
+        ],
+    )
+
+    entries = create_diun_yaml([container], m_all=True, compose_track=True)
+
+    assert entries[0]["metadata"]["current_digest"] == "sha256:027002f3"
+    assert entries[0]["metadata"]["current_repo_digests"] == [
+        "sha256:027002f3",
+        "sha256:2838d552",
+    ]
 
 
 def test_enrich_missing_current_digests_uses_matching_manifest_digest():
@@ -113,6 +136,27 @@ def test_enrich_missing_current_digests_uses_matching_manifest_digest():
     enrich_missing_current_digests(entries, manifest_lookup)
 
     assert entries[0]["metadata"]["current_digest"] == "sha256:manifest-digest"
+
+
+def test_enrich_missing_current_digests_does_not_overwrite_docker_digest():
+    entries = [
+        {
+            "name": "redis:8.8.0",
+            "metadata": {
+                "current_tag": "8.8.0",
+                "current_digest": "sha256:docker-digest",
+            },
+        }
+    ]
+    manifest_lookup = {
+        "library/redis": [
+            {"tag": "8.8.0", "digest": "sha256:registry-digest"},
+        ]
+    }
+
+    enrich_missing_current_digests(entries, manifest_lookup)
+
+    assert entries[0]["metadata"]["current_digest"] == "sha256:docker-digest"
 
 
 def test_create_empty_yaml_does_not_overwrite_existing(tmp_path):


### PR DESCRIPTION
## Summary

This PR prepares `diun-boost` for the `1.4.5` release with two dashboard improvements:

- Fixes false-positive `digest_refresh` entries when Docker has multiple repo digests for the same image.
- Adds optional manually configured release notes links to the DIUN dashboard.

## Changes

### Digest refresh detection

Previously, the dashboard compared DIUN’s latest registry digest against a single stored `current_digest`. This caused false positives when Docker had multiple `RepoDigests` for the same image and DIUN’s latest digest was present locally but was not the first digest stored.

This PR now:

- Captures all Docker repo digests for the running container image.
- Stores them as `metadata.current_repo_digests`.
- Keeps `metadata.current_digest` for backward compatibility.
- Treats an image as current when DIUN’s latest digest exists in `current_repo_digests`.
- Preserves backward compatibility when older config entries do not have `current_repo_digests`.

### Release notes links

Users can now manually add a release notes URL in `config.yml`:

```yaml
metadata:
  release_notes_url: https://github.com/redis/redis/releases