### PR TITLE
hotfix: encode repo digests metadata as JSON string

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,7 @@ Example:
   metadata:
     current_tag: 8.8.0
     current_digest: sha256:...
-    current_repo_digests:
-      - sha256:...
+    current_repo_digests: '["sha256:..."]'
     compose_project: paperless
     compose_service: paperless-redis
     release_notes_url: https://github.com/redis/redis/releases
@@ -298,8 +297,7 @@ providers:
   metadata:
     current_tag: 4.0.17
     current_digest: sha256:...
-    current_repo_digests:
-      - sha256:...
+    current_repo_digests: '["sha256:..."]'
     compose_project: arr-stack
     compose_service: sonarr
     release_notes_url: https://github.com/linuxserver/docker-sonarr/releases

--- a/app/dashboard_snapshot.py
+++ b/app/dashboard_snapshot.py
@@ -10,6 +10,8 @@ from pathlib import Path
 
 import yaml
 
+from app.yaml_helper import parse_repo_digests
+
 
 def canonical_image_name(name: str) -> str:
     name = name.removeprefix("docker.io/")
@@ -93,12 +95,8 @@ def build_dashboard_snapshot(
         current_tag = metadata.get("current_tag")
         current_digest = metadata.get("current_digest")
         release_notes_url = metadata.get("release_notes_url")
-        raw_current_repo_digests = metadata.get("current_repo_digests")
-        current_repo_digests = (
-            [digest for digest in raw_current_repo_digests if isinstance(digest, str) and digest]
-            if isinstance(raw_current_repo_digests, Sequence)
-            and not isinstance(raw_current_repo_digests, (str, bytes))
-            else []
+        current_repo_digests = parse_repo_digests(
+            metadata.get("current_repo_digests")
         )
         full_image = entry.get("name")
         if not all(isinstance(value, str) and value for value in [project, service, current_tag, full_image]):

--- a/app/yaml_helper.py
+++ b/app/yaml_helper.py
@@ -1,10 +1,10 @@
+import json
 from typing import Dict, List
 
 import yaml
 from docker.models.containers import Container
 from loguru import logger
 
-from app.dashboard_snapshot import canonical_image_name
 from app.docker_client import get_container_current_digest, get_container_repo_digests
 from app.regex_helper import build_tag_regex
 
@@ -15,6 +15,18 @@ AUTO_METADATA_KEYS = {
     "compose_project",
     "compose_service",
 }
+
+
+def parse_repo_digests(value) -> list[str]:
+    if not isinstance(value, str) or not value.strip():
+        return []
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError:
+        return []
+    if not isinstance(parsed, list):
+        return []
+    return [item for item in parsed if isinstance(item, str) and item]
 
 
 def create_diun_yaml(
@@ -59,7 +71,10 @@ def create_diun_yaml(
         if current_digest:
             metadata["current_digest"] = current_digest
         if current_repo_digests:
-            metadata["current_repo_digests"] = current_repo_digests
+            metadata["current_repo_digests"] = json.dumps(
+                current_repo_digests,
+                separators=(",", ":"),
+            )
         entry = {"name": image, "notify_on": ["update"], "metadata": metadata}
 
         if "com.docker.compose.project" in container.labels and compose_track:
@@ -185,6 +200,8 @@ def merge_custom_metadata(
 def enrich_missing_current_digests(
     entries: List[Dict], manifest_lookup: Dict[str, List[Dict]]
 ) -> List[Dict]:
+    from app.dashboard_snapshot import canonical_image_name
+
     for entry in entries:
         if not isinstance(entry, dict):
             continue

--- a/tests/test_dashboard_snapshot.py
+++ b/tests/test_dashboard_snapshot.py
@@ -116,7 +116,9 @@ def test_build_dashboard_snapshot_skips_digest_refresh_when_latest_is_in_repo_di
                     "compose_service": "paperless-redis",
                     "current_tag": "8.8.0",
                     "current_digest": "sha256:027002f3",
-                    "current_repo_digests": ["sha256:027002f3", "sha256:2838d552"],
+                    "current_repo_digests": (
+                        '["sha256:027002f3","sha256:2838d552"]'
+                    ),
                 },
             }
         ],
@@ -146,7 +148,7 @@ def test_build_dashboard_snapshot_reports_digest_refresh_when_latest_missing_fro
                     "compose_service": "paperless-redis",
                     "current_tag": "8.8.0",
                     "current_digest": "sha256:027002f3",
-                    "current_repo_digests": ["sha256:027002f3"],
+                    "current_repo_digests": '["sha256:027002f3"]',
                 },
             }
         ],

--- a/tests/test_yaml_helper.py
+++ b/tests/test_yaml_helper.py
@@ -1,10 +1,13 @@
 from types import SimpleNamespace
 
+import yaml
+
 from app.yaml_helper import (
     create_diun_yaml,
     create_empty_yaml,
     enrich_missing_current_digests,
     merge_custom_metadata,
+    parse_repo_digests,
 )
 
 
@@ -92,7 +95,7 @@ def test_create_diun_yaml_includes_current_digest_metadata():
 
     assert entries[0]["metadata"]["current_tag"] == "4.0.17"
     assert entries[0]["metadata"]["current_digest"] == "sha256:abcdef123456"
-    assert entries[0]["metadata"]["current_repo_digests"] == ["sha256:abcdef123456"]
+    assert entries[0]["metadata"]["current_repo_digests"] == '["sha256:abcdef123456"]'
     assert entries[0]["metadata"]["compose_project"] == "arr-stack"
     assert entries[0]["metadata"]["compose_service"] == "sonarr"
 
@@ -111,10 +114,54 @@ def test_create_diun_yaml_includes_all_current_repo_digests():
     entries = create_diun_yaml([container], m_all=True, compose_track=True)
 
     assert entries[0]["metadata"]["current_digest"] == "sha256:027002f3"
-    assert entries[0]["metadata"]["current_repo_digests"] == [
+    assert (
+        entries[0]["metadata"]["current_repo_digests"]
+        == '["sha256:027002f3","sha256:2838d552"]'
+    )
+
+
+def test_parse_repo_digests_parses_json_string():
+    assert parse_repo_digests('["sha256:027002f3","sha256:2838d552"]') == [
         "sha256:027002f3",
         "sha256:2838d552",
     ]
+
+
+def test_parse_repo_digests_filters_non_string_and_empty_items():
+    assert parse_repo_digests('["sha256:027002f3", "", null, 3]') == [
+        "sha256:027002f3",
+    ]
+
+
+def test_parse_repo_digests_returns_empty_for_missing_empty_invalid_or_non_list_json():
+    invalid_values = [
+        None,
+        "",
+        "   ",
+        "not json",
+        '{"digest":"sha256:027002f3"}',
+        '"sha256:027002f3"',
+        ["sha256:027002f3"],
+    ]
+
+    for value in invalid_values:
+        assert parse_repo_digests(value) == []
+
+
+def test_create_diun_yaml_keeps_notify_on_and_include_tags_as_yaml_lists():
+    container = make_container(
+        name="redis",
+        image_tag="redis:8.8.0",
+        repo_digests=["redis@sha256:027002f3"],
+    )
+
+    entries = create_diun_yaml([container], m_all=True, compose_track=True)
+    loaded = yaml.safe_load(yaml.safe_dump(entries))
+
+    assert loaded[0]["notify_on"] == ["new", "update"]
+    assert isinstance(loaded[0]["notify_on"], list)
+    assert isinstance(loaded[0]["include_tags"], list)
+    assert isinstance(loaded[0]["metadata"]["current_repo_digests"], str)
 
 
 def test_enrich_missing_current_digests_uses_matching_manifest_digest():


### PR DESCRIPTION
DIUN metadata values must be scalar strings, but current_repo_digests was generated as a YAML list. That caused DIUN to reject the generated config with "cannot unmarshal !!seq into string".
Keep all repo digests for false-positive prevention, but serialize current_repo_digests as a compact JSON string under metadata so DIUN sees a scalar value. Add parse_repo_digests for dashboard/comparison reads and intentionally do not support the old YAML-list metadata format.
Update tests to verify JSON-string generation, parser failure cases, dashboard digest comparison behavior, and that notify_on/include_tags remain YAML lists.