### PR TITLE
feat: add custom dashboard action buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Recent changes added a proper dashboard-oriented workflow:
 - dashboard downgrade protection skips latest tags that are numerically older than the current tag
 - preserved custom metadata on YAML regeneration
 - optional manually configured release-notes links in the dashboard
+- configurable Custom Action Buttons that copy rendered dashboard commands/text
 - initial startup now creates the YAML file only if it does not already exist
 
 ## Features
@@ -127,6 +128,117 @@ Example:
     - ^8\.8\..+$
 ```
 
+### Custom Action Buttons
+
+Custom Action Buttons let you define copyable dashboard actions using update details and metadata. This makes diun-boost workflow-aware without making it workflow-specific. You can copy commands for Docker Compose, GitOps, Kubernetes, Ansible, custom scripts, commit messages, release notes, or any other workflow.
+
+Custom Action Buttons are configured separately from DIUN's file-provider config. By default, diun-boost reads action button configuration from:
+
+```text
+/config/dashboard.yml
+```
+
+This file should contain a `dashboard.commands` section. Do not put `dashboard.commands` in `/config/config.yml`, because `config.yml` is generated for DIUN's file provider and should remain DIUN-compatible. If `/config/dashboard.yml` is missing or empty, no custom action buttons are shown. Override the path with `DIUN_DASHBOARD_COMMANDS_PATH` if needed.
+
+Safety note: diun-boost only renders commands/text and copies the raw result to your clipboard. It does not execute commands, shell-escape values, quote values, or modify command text beyond placeholder replacement.
+
+Supported scopes:
+
+- `service`: renders one copy button per matching service row, beside the release-notes button. Requires `template`.
+- `project`: renders one copy button near the project/card header. Use either:
+  - `item_template` to render one fragment per matching service and join them with `join_with`, then wrap with optional `prefix` and `suffix`.
+  - `template` to render one project-level command. For project-level `template`, only `{project}` is available.
+
+Available icon names are `code`, `copy`, `file-text`, `play`, `refresh`, `rocket`, and `terminal`. Invalid or missing icons fall back to `code`.
+
+`update_types` is a filter, not a scope. If omitted, the command applies to all update types. If set, only matching services are included. This is useful because `tag_bump` and `digest_refresh` often need different workflows: a `tag_bump` usually requires updating the declared image tag first, while a plain `docker compose pull` is usually only appropriate for `digest_refresh` where the tag is unchanged.
+
+Supported built-in placeholders for service commands and project `item_template` commands:
+
+- `{service}`
+- `{current}`
+- `{latest}`
+- `{update_type}`
+- `{release_notes_url}`
+- `{project}`
+
+All metadata keys are also available to service commands and project `item_template` commands, for example:
+
+- `{compose_project}`
+- `{compose_service}`
+- `{image_repo}`
+- `{current_tag}`
+- `{current_digest}`
+- `{current_repo_digests}`
+
+If a placeholder is missing, the related button is disabled and its tooltip explains what is missing, for example `Missing placeholder: compose_service`. For project `item_template` commands, a service with missing placeholders is skipped and logged so the remaining services can still produce a copyable command.
+
+Example `/config/dashboard.yml`:
+
+```yaml
+dashboard:
+  commands:
+    # Simple service-level workflow: copy an update note
+    - name: update-note
+      scope: service
+      label: Update note
+      icon: file-text
+      template: "{service}: {current} → {latest} ({update_type})"
+
+    # Advanced service-level workflow: refresh an unchanged tag/digest
+    - name: refresh-digest
+      scope: service
+      label: Refresh digest
+      icon: refresh
+      update_types:
+        - digest_refresh
+      template: "docker compose -p {compose_project} pull {compose_service} && docker compose -p {compose_project} up -d {compose_service}"
+
+    # Simple project-level workflow: copy one summary for all matching services
+    - name: project-summary
+      scope: project
+      label: Project summary
+      icon: file-text
+      item_template: "{service}: {current} → {latest}"
+      join_with: ", "
+
+    # Project-level workflow: copy one command for the matching project
+    - name: refresh-project
+      scope: project
+      label: Refresh project
+      icon: rocket
+      update_types:
+        - digest_refresh
+      template: "hc update {project}"
+
+    # Advanced project-level workflow: bump all tag updates, then recreate the compose project
+    - name: bump-all-tags
+      scope: project
+      label: Bump all tags
+      icon: rocket
+      update_types:
+        - tag_bump
+      item_template: "yq -i '.services.{compose_service}.image = \"{image_repo}:{latest}\"' docker-compose.yml"
+      join_with: " && "
+      suffix: " && docker compose -p {compose_project} up -d"
+```
+
+Digest refresh project workflow using one command fragment per matching service:
+
+```yaml
+dashboard:
+  commands:
+    - name: refresh-all-digests
+      scope: project
+      label: Refresh all digests
+      icon: refresh
+      update_types:
+        - digest_refresh
+      item_template: "docker compose -p {compose_project} pull {compose_service}"
+      join_with: " && "
+      suffix: " && docker compose -p {compose_project} up -d"
+```
+
 ### Dashboard for pending updates
 
 The dashboard snapshot groups updates by Compose project and shows:
@@ -136,6 +248,8 @@ The dashboard snapshot groups updates by Compose project and shows:
 - current tag
 - latest tag
 - optional `Release notes ↗` link when `metadata.release_notes_url` is configured
+- optional Custom Action Buttons from `dashboard.commands`
+- service metadata under each service's nested `metadata` object
 - summary counts for projects, services, tag bumps, and digest refreshes
 
 Dashboard candidate selection follows the same generated `include_tags` rules used by DIUN. This prevents the dashboard from showing an update candidate that DIUN itself would not watch. It also skips numeric downgrades, so a registry-reported `4.0.0` latest tag will not be reported as pending when the running container is already on `4.0.1`.
@@ -196,6 +310,7 @@ If Compose metadata is disabled, diun-boost can still generate `config.yml`, but
 |---|---|---|
 | `DIUN_YAML_PATH` | Path to the generated DIUN file-provider YAML. | `/config/config.yml` |
 | `DIUN_DASHBOARD_JSON_PATH` | Path to the generated dashboard snapshot JSON. | `/config/dashboard.json` |
+| `DIUN_DASHBOARD_COMMANDS_PATH` | Path to `dashboard.yml` containing `dashboard.commands` for Custom Action Buttons. | `/config/dashboard.yml` |
 | `CRON_SCHEDULE` | Cron expression for regenerating `config.yml`. | `0 */6 * * *` |
 | `DIUN_DASHBOARD_CRON_SCHEDULE` | Cron expression for regenerating `dashboard.json`. | `7 */6 * * *` |
 | `LOG_LEVEL` | Logging level: `DEBUG`, `INFO`, `WARNING`, `ERROR`. | `INFO` |
@@ -214,6 +329,7 @@ docker run -d \
   -p 8000:8000 \
   -e DIUN_YAML_PATH="/config/config.yml" \
   -e DIUN_DASHBOARD_JSON_PATH="/config/dashboard.json" \
+  -e DIUN_DASHBOARD_COMMANDS_PATH="/config/dashboard.yml" \
   -e CRON_SCHEDULE="0 */6 * * *" \
   -e DIUN_DASHBOARD_CRON_SCHEDULE="7 */6 * * *" \
   -e LOG_LEVEL="INFO" \
@@ -259,6 +375,7 @@ services:
     environment:
       - DIUN_YAML_PATH=/config/config.yml
       - DIUN_DASHBOARD_JSON_PATH=/config/dashboard.json
+      - DIUN_DASHBOARD_COMMANDS_PATH=/config/dashboard.yml
       - CRON_SCHEDULE=0 */6 * * *
       - DIUN_DASHBOARD_CRON_SCHEDULE=7 */6 * * *
       - LOG_LEVEL=INFO
@@ -313,7 +430,7 @@ User-defined metadata like `team`, `severity`, and `release_notes_url` is preser
 ## Dashboard API
 
 - `GET /` - HTML dashboard
-- `GET /api/report` - return the current `dashboard.json`
+- `GET /api/report` - return the current `dashboard.json`, including top-level `commands` and nested service `metadata`
 - `POST /api/report/refresh` - perform a targeted live refresh and return the refreshed snapshot
 - `POST /api/report/hard-refresh` - perform a full live refresh, update `config.yml` if needed, and return the refreshed snapshot
 - `GET /healthz` - simple health endpoint
@@ -331,6 +448,7 @@ User-defined metadata like `team`, `severity`, and `release_notes_url` is preser
 - If `dashboard.json` already shows no pending services, the targeted refresh path returns that snapshot as-is.
 - The dashboard ignores latest tags that do not match an entry's `include_tags` rules.
 - The dashboard ignores numeric downgrades when both the current and latest tags contain version numbers.
+- Custom Action Buttons copy rendered raw text to the clipboard only; diun-boost never executes configured commands.
 - Use hard refresh when you want to rescan all eligible containers instead of only refreshing services already shown as pending.
 
 ## Local development

--- a/app/dashboard_snapshot.py
+++ b/app/dashboard_snapshot.py
@@ -9,8 +9,104 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import yaml
+from loguru import logger
 
 from app.yaml_helper import parse_repo_digests
+
+
+VALID_COMMAND_ICONS = {
+    "code",
+    "copy",
+    "file-text",
+    "play",
+    "refresh",
+    "rocket",
+    "terminal",
+}
+
+
+def normalize_dashboard_commands(commands: object) -> list[dict[str, object]]:
+    if not isinstance(commands, Sequence) or isinstance(commands, (str, bytes)):
+        return []
+
+    normalized: list[dict[str, object]] = []
+    seen_names: set[str] = set()
+    for command in commands:
+        if not isinstance(command, Mapping):
+            continue
+
+        name = command.get("name")
+        scope = command.get("scope")
+        label = command.get("label")
+        if not all(isinstance(value, str) and value.strip() for value in [name, scope, label]):
+            continue
+        if not isinstance(name, str) or not isinstance(scope, str) or not isinstance(label, str):
+            continue
+        if name in seen_names or scope not in {"service", "project"}:
+            continue
+
+        item: dict[str, object] = {
+            "name": name,
+            "scope": scope,
+            "label": label,
+            "icon": command.get("icon") if command.get("icon") in VALID_COMMAND_ICONS else "code",
+        }
+
+        raw_update_types = command.get("update_types")
+        if isinstance(raw_update_types, Sequence) and not isinstance(raw_update_types, (str, bytes)):
+            update_types = [value for value in raw_update_types if isinstance(value, str) and value]
+            if update_types:
+                item["update_types"] = update_types
+
+        if scope == "service":
+            template = command.get("template")
+            if not isinstance(template, str) or not template:
+                continue
+            item["template"] = template
+        else:
+            item_template = command.get("item_template")
+            template = command.get("template")
+            if isinstance(item_template, str) and item_template:
+                item["item_template"] = item_template
+                item["join_with"] = command.get("join_with") if isinstance(command.get("join_with"), str) else " && "
+                item["prefix"] = command.get("prefix") if isinstance(command.get("prefix"), str) else ""
+                item["suffix"] = command.get("suffix") if isinstance(command.get("suffix"), str) else ""
+            elif isinstance(template, str) and template:
+                item["template"] = template
+            else:
+                continue
+
+        seen_names.add(name)
+        normalized.append(item)
+    return normalized
+
+
+def extract_dashboard_commands(config: object) -> list[dict[str, object]]:
+    if isinstance(config, Mapping):
+        dashboard = config.get("dashboard")
+        if isinstance(dashboard, Mapping):
+            return normalize_dashboard_commands(dashboard.get("commands"))
+        return []
+
+    if isinstance(config, Sequence) and not isinstance(config, (str, bytes)):
+        for item in config:
+            if not isinstance(item, Mapping):
+                continue
+            dashboard = item.get("dashboard")
+            if isinstance(dashboard, Mapping):
+                return normalize_dashboard_commands(dashboard.get("commands"))
+    return []
+
+
+def load_dashboard_commands_from_yaml(file_path: str | Path) -> list[dict[str, object]]:
+    path = Path(file_path)
+    if not path.exists():
+        return []
+    try:
+        return extract_dashboard_commands(yaml.safe_load(path.read_text()) or {})
+    except yaml.YAMLError as exc:
+        logger.warning(f"Unable to parse dashboard command config {path}: {exc}")
+        return []
 
 
 def canonical_image_name(name: str) -> str:
@@ -79,9 +175,10 @@ def build_dashboard_snapshot(
     config_entries: Sequence[Mapping[str, object]],
     latest_by_image: Mapping[str, Mapping[str, object]],
     manifest_lookup: Mapping[str, Sequence[Mapping[str, object]]] | None = None,
+    dashboard_commands: Sequence[Mapping[str, object]] | None = None,
     generated_at: datetime | None = None,
 ) -> dict[str, object]:
-    grouped: dict[str, list[dict[str, str]]] = defaultdict(list)
+    grouped: dict[str, list[dict[str, object]]] = defaultdict(list)
     tag_bumps = 0
     digest_refreshes = 0
 
@@ -155,6 +252,7 @@ def build_dashboard_snapshot(
             "update_type": update_type,
             "current": current_tag,
             "latest": latest_tag,
+            "metadata": dict(metadata),
         }
         if is_valid_release_notes_url(release_notes_url):
             service_item["release_notes_url"] = release_notes_url
@@ -162,7 +260,7 @@ def build_dashboard_snapshot(
         grouped[project].append(service_item)
 
     projects = [
-        {"name": project, "services": sorted(services, key=lambda item: item["service"])}
+        {"name": project, "services": sorted(services, key=lambda item: str(item["service"]))}
         for project, services in sorted(grouped.items())
     ]
     service_count = sum(len(project["services"]) for project in projects)
@@ -175,6 +273,7 @@ def build_dashboard_snapshot(
 
     return {
         "generated_at": (generated_at or datetime.now(timezone.utc)).isoformat(),
+        "commands": normalize_dashboard_commands(dashboard_commands),
         "projects": projects,
         "summary": summary,
     }

--- a/app/main.py
+++ b/app/main.py
@@ -10,6 +10,7 @@ from app.dashboard_snapshot import (
     build_dashboard_snapshot,
     canonical_image_name,
     extract_pending_service_scope,
+    load_dashboard_commands_from_yaml,
     load_dashboard_json,
     write_dashboard_json,
 )
@@ -33,6 +34,7 @@ DEFAULT_MONITOR_ALL = os.getenv("WATCHBYDEFAULT", "false").lower() == "true"
 DEFAULT_COMPOSE_TRACK = os.getenv("DOCKER_COMPOSE_METADATA", "false").lower() == "true"
 DEFAULT_OUTPUT_PATH = os.getenv("DIUN_YAML_PATH", "/config/config.yml")
 DEFAULT_DASHBOARD_JSON_PATH = os.getenv("DIUN_DASHBOARD_JSON_PATH", "/config/dashboard.json")
+DEFAULT_DASHBOARD_COMMANDS_PATH = os.getenv("DIUN_DASHBOARD_COMMANDS_PATH", "/config/dashboard.yml")
 DEFAULT_DIUN_CONTAINER_NAME = os.getenv("DIUN_CONTAINER_NAME", "diun")
 DEFAULT_DASHBOARD_CRON_SCHEDULE = os.getenv("DIUN_DASHBOARD_CRON_SCHEDULE", "7 */6 * * *")
 
@@ -74,6 +76,7 @@ def build_manifest_lookup(
 def build_snapshot_from_entries(
     entries: list[dict],
     diun_container_name: str,
+    dashboard_commands: list[dict] | None = None,
 ) -> dict[str, object]:
     client = get_docker_client()
     latest_by_image = load_diun_latest(client, diun_container_name)
@@ -88,6 +91,7 @@ def build_snapshot_from_entries(
         entries,
         latest_by_image,
         manifest_lookup=manifest_lookup,
+        dashboard_commands=dashboard_commands,
     )
 
 
@@ -124,14 +128,22 @@ def generate_dashboard_snapshot(
     if persist_yaml and compare_yaml_files(output_path, diun_entries):
         write_yaml_to_file(diun_entries, output_path)
 
-    return build_snapshot_from_entries(diun_entries, diun_container_name)
+    return build_snapshot_from_entries(
+        diun_entries,
+        diun_container_name,
+        load_dashboard_commands_from_yaml(DEFAULT_DASHBOARD_COMMANDS_PATH),
+    )
 
 
 def generate_dashboard_snapshot_from_yaml(
     output_path: str,
     diun_container_name: str,
 ) -> dict[str, object]:
-    return build_snapshot_from_entries(load_yaml_entries(output_path), diun_container_name)
+    return build_snapshot_from_entries(
+        load_yaml_entries(output_path),
+        diun_container_name,
+        load_dashboard_commands_from_yaml(DEFAULT_DASHBOARD_COMMANDS_PATH),
+    )
 
 
 def generate_targeted_dashboard_snapshot(
@@ -160,7 +172,11 @@ def generate_targeted_dashboard_snapshot(
     scoped_existing_entries = filter_entries_for_scope(existing_entries, scope)
     diun_entries = create_diun_yaml(containers, True, compose_track)
     diun_entries = merge_custom_metadata(diun_entries, scoped_existing_entries)
-    return build_snapshot_from_entries(diun_entries, diun_container_name)
+    return build_snapshot_from_entries(
+        diun_entries,
+        diun_container_name,
+        load_dashboard_commands_from_yaml(DEFAULT_DASHBOARD_COMMANDS_PATH),
+    )
 
 
 def run_tasks(

--- a/app/static/app.js
+++ b/app/static/app.js
@@ -54,7 +54,211 @@ function updateRefreshStatus(value) {
   }
 }
 
-function renderServiceRow(service) {
+const VALID_COMMAND_ICONS = new Set(["code", "copy", "file-text", "play", "refresh", "rocket", "terminal"]);
+
+function getCommandIconName(icon) {
+  return VALID_COMMAND_ICONS.has(icon) ? icon : "code";
+}
+
+function renderCommandIcon(icon) {
+  const iconName = getCommandIconName(icon);
+  const paths = {
+    code: '<path d="m16 18 6-6-6-6"/><path d="m8 6-6 6 6 6"/>',
+    copy: '<rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>',
+    "file-text": '<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6"/><path d="M16 13H8"/><path d="M16 17H8"/><path d="M10 9H8"/>',
+    play: '<path d="M5 3l14 9-14 9V3z"/>',
+    refresh: '<path d="M21 2v6h-6"/><path d="M3 12a9 9 0 0 1 15-6.7L21 8"/><path d="M3 22v-6h6"/><path d="M21 12a9 9 0 0 1-15 6.7L3 16"/>',
+    rocket: '<path d="M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09z"/><path d="m12 15-3-3a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22 22 0 0 1-4 2z"/><path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 0 5 0"/><path d="M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5"/>',
+    terminal: '<path d="m4 17 6-6-6-6"/><path d="M12 19h8"/>',
+  };
+  return `<svg class="command-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${paths[iconName]}</svg>`;
+}
+
+function getCommandsByScope(commands, scope) {
+  return (Array.isArray(commands) ? commands : []).filter((command) => command?.scope === scope);
+}
+
+function commandAppliesToUpdateType(command, updateType) {
+  return !Array.isArray(command.update_types)
+    || command.update_types.length === 0
+    || command.update_types.includes(updateType);
+}
+
+function buildPlaceholderContext(service, project) {
+  const metadata = service && typeof service.metadata === "object" && service.metadata !== null ? service.metadata : {};
+  const context = {
+    project: project?.name,
+    service: service?.service,
+    current: service?.current,
+    latest: service?.latest,
+    update_type: service?.update_type,
+    ...metadata,
+  };
+
+  if (typeof service?.release_notes_url === "string" && service.release_notes_url) {
+    context.release_notes_url = service.release_notes_url;
+  }
+
+  return context;
+}
+
+function renderCommandTemplate(template, context) {
+  const missing = [];
+  const seenMissing = new Set();
+  const text = String(template ?? "").replace(/\{([^{}]+)\}/g, (match, key) => {
+    if (!Object.prototype.hasOwnProperty.call(context, key) || context[key] === undefined || context[key] === null) {
+      if (!seenMissing.has(key)) {
+        seenMissing.add(key);
+        missing.push(key);
+      }
+      return match;
+    }
+    return String(context[key]);
+  });
+
+  return missing.length ? { text: null, missing } : { text, missing: [] };
+}
+
+function formatMissingPlaceholders(missing) {
+  return missing.length === 1
+    ? `Missing placeholder: ${missing[0]}`
+    : `Missing placeholders: ${missing.join(", ")}`;
+}
+
+function renderCommandButton(command, rendered, options = {}) {
+  const iconName = getCommandIconName(command.icon);
+  const title = `Copy ${command.label} command`;
+  const classes = ["command-button"];
+  if (options.compact) classes.push("command-button-compact");
+  if (!options.compact) classes.push("command-button-labeled");
+
+  if (rendered.missing.length) {
+    const missingTitle = formatMissingPlaceholders(rendered.missing);
+    return `<button class="${classes.join(" ")}" type="button" title="${escapeHtml(missingTitle)}" aria-label="${escapeHtml(missingTitle)}" data-icon="${escapeHtml(iconName)}" disabled>
+      ${renderCommandIcon(iconName)}
+      ${options.compact ? "" : `<span>${escapeHtml(command.label)}</span>`}
+    </button>`;
+  }
+
+  return `<button class="${classes.join(" ")}" type="button" title="${escapeHtml(title)}" aria-label="${escapeHtml(title)}" data-icon="${escapeHtml(iconName)}" data-command-text="${escapeHtml(rendered.text)}">
+    ${renderCommandIcon(iconName)}
+    ${options.compact ? `<span class="sr-only">${escapeHtml(title)}</span>` : `<span>${escapeHtml(command.label)}</span>`}
+  </button>`;
+}
+
+function renderServiceCommandButtons(service, project, commands) {
+  return getCommandsByScope(commands, "service")
+    .filter((command) => commandAppliesToUpdateType(command, service.update_type))
+    .map((command) => renderCommandButton(
+      command,
+      renderCommandTemplate(command.template, buildPlaceholderContext(service, project)),
+      { compact: true },
+    ))
+    .join("");
+}
+
+function renderProjectCommand(command, project) {
+  const services = (Array.isArray(project.services) ? project.services : [])
+    .filter((service) => commandAppliesToUpdateType(command, service.update_type));
+  if (!services.length) return null;
+
+  if (typeof command.template === "string" && command.template && !command.item_template) {
+    return renderCommandTemplate(command.template, { project: project?.name });
+  }
+
+  const missing = [];
+  const seenMissing = new Set();
+  const collectMissing = (items) => {
+    items.forEach((item) => {
+      if (!seenMissing.has(item)) {
+        seenMissing.add(item);
+        missing.push(item);
+      }
+    });
+  };
+
+  const firstContext = buildPlaceholderContext(services[0], project);
+  const prefix = renderCommandTemplate(command.prefix || "", firstContext);
+  const suffix = renderCommandTemplate(command.suffix || "", firstContext);
+  collectMissing(prefix.missing);
+  collectMissing(suffix.missing);
+
+  const itemTexts = [];
+  services.forEach((service) => {
+    const rendered = renderCommandTemplate(command.item_template, buildPlaceholderContext(service, project));
+    if (rendered.missing.length) {
+      console.warn(
+        `Skipping command ${command.name} for service ${service.service}: ${formatMissingPlaceholders(rendered.missing)}`,
+      );
+      collectMissing(rendered.missing);
+      return;
+    }
+    itemTexts.push(rendered.text);
+  });
+
+  if (prefix.missing.length || suffix.missing.length) return { text: null, missing };
+  if (!itemTexts.length) return { text: null, missing };
+  return {
+    text: `${prefix.text}${itemTexts.join(command.join_with ?? " && ")}${suffix.text}`,
+    missing: [],
+  };
+}
+
+function renderProjectCommandButtons(project, commands) {
+  return getCommandsByScope(commands, "project")
+    .map((command) => {
+      const rendered = renderProjectCommand(command, project);
+      return rendered ? renderCommandButton(command, rendered, { compact: false }) : "";
+    })
+    .join("");
+}
+
+function showToast(message) {
+  let toast = document.getElementById("command-toast");
+  if (!toast) {
+    toast = document.createElement("div");
+    toast.id = "command-toast";
+    toast.className = "toast";
+    toast.setAttribute("role", "status");
+    toast.setAttribute("aria-live", "polite");
+    document.body.appendChild(toast);
+  }
+
+  toast.textContent = message;
+  toast.classList.add("toast-visible");
+  window.setTimeout(() => toast.classList.remove("toast-visible"), 1800);
+}
+
+async function copyTextToClipboard(text) {
+  if (navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(text);
+    return;
+  }
+
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "fixed";
+  textarea.style.left = "-9999px";
+  document.body.appendChild(textarea);
+  textarea.select();
+  document.execCommand("copy");
+  textarea.remove();
+}
+
+async function handleCommandButtonClick(event) {
+  const button = event.target.closest?.("button[data-command-text]");
+  if (!button) return;
+
+  try {
+    await copyTextToClipboard(button.dataset.commandText);
+    showToast("Command copied.");
+  } catch (error) {
+    showToast("Unable to copy command.");
+  }
+}
+
+function renderServiceRow(service, project, commands = []) {
   const serviceName = escapeHtml(service.service);
   const releaseNotesLink = typeof service.release_notes_url === "string" && service.release_notes_url
     ? `<a class="release-notes-icon-link" href="${escapeHtml(service.release_notes_url)}" target="_blank" rel="noopener noreferrer" title="Release notes" aria-label="Release notes for ${serviceName}">
@@ -73,7 +277,10 @@ function renderServiceRow(service) {
       <td class="service-name">
         <div class="service-title-row">
           <span class="service-title">${serviceName}</span>
-          ${releaseNotesLink}
+          <span class="service-actions">
+            ${releaseNotesLink}
+            ${renderServiceCommandButtons(service, project, commands)}
+          </span>
         </div>
       </td>
       <td><span class="badge badge-${escapeHtml(service.update_type.replaceAll("_", "-"))}">${escapeHtml(service.update_type)}</span></td>
@@ -83,10 +290,11 @@ function renderServiceRow(service) {
   `;
 }
 
-function renderProject(project) {
+function renderProject(project, commands = []) {
   const services = Array.isArray(project.services) ? project.services : [];
-  const rows = services.map(renderServiceRow).join("");
+  const rows = services.map((service) => renderServiceRow(service, project, commands)).join("");
   const serviceCount = project.service_count ?? services.length;
+  const projectCommandButtons = renderProjectCommandButtons(project, commands);
   return `
     <section class="panel project-panel">
       <div class="project-header">
@@ -94,7 +302,10 @@ function renderProject(project) {
           <h2>${escapeHtml(project.name)}</h2>
           <p class="subtle">${escapeHtml(serviceCount)} impacted service(s)</p>
         </div>
-        <span class="project-chip">Project</span>
+        <div class="project-actions">
+          ${projectCommandButtons}
+          <span class="project-chip">Project</span>
+        </div>
       </div>
       <div class="table-wrap">
         <table>
@@ -116,6 +327,7 @@ function renderProject(project) {
 function renderDashboard(data) {
   const summary = data.summary || { projects: 0, services: 0, tag_bumps: 0, digest_refreshes: 0 };
   const projects = Array.isArray(data.projects) ? data.projects : [];
+  const commands = Array.isArray(data.commands) ? data.commands : [];
 
   const summaryHtml = `
     <section class="summary-grid">
@@ -156,7 +368,7 @@ function renderDashboard(data) {
     `;
   }
 
-  return summaryHtml + projects.map(renderProject).join("");
+  return summaryHtml + projects.map((project) => renderProject(project, commands)).join("");
 }
 
 function renderError(error) {
@@ -219,6 +431,13 @@ async function refreshDashboard(options = {}) {
 }
 
 document.addEventListener("DOMContentLoaded", () => {
+  document.addEventListener("click", handleCommandButtonClick);
+
+  const root = document.getElementById("dashboard-root");
+  if (root && window.__DIUN_DASHBOARD__) {
+    root.innerHTML = renderDashboard(window.__DIUN_DASHBOARD__);
+  }
+
   const button = document.getElementById("refresh-button");
   if (button) {
     button.addEventListener("click", () => refreshDashboard({ button }));

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -378,6 +378,108 @@ td.service-name {
   height: 0.9rem;
 }
 
+.service-actions,
+.project-actions {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.project-actions {
+  justify-content: flex-end;
+}
+
+.command-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  min-height: 1.45rem;
+  border-radius: 999px;
+  color: rgba(199, 210, 254, 0.9);
+  background: rgba(99, 102, 241, 0.10);
+  border: 1px solid rgba(165, 180, 252, 0.22);
+  font: inherit;
+  font-size: 0.78rem;
+  cursor: pointer;
+  transition:
+    color 120ms ease,
+    background 120ms ease,
+    border-color 120ms ease,
+    transform 120ms ease,
+    opacity 120ms ease;
+}
+
+.command-button:hover:not(:disabled) {
+  color: #eef2ff;
+  background: rgba(99, 102, 241, 0.20);
+  border-color: rgba(199, 210, 254, 0.50);
+  transform: translateY(-1px);
+}
+
+.command-button:focus-visible {
+  outline: 2px solid rgba(199, 210, 254, 0.65);
+  outline-offset: 2px;
+}
+
+.command-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.48;
+}
+
+.command-button-compact {
+  width: 1.45rem;
+  height: 1.45rem;
+  padding: 0;
+}
+
+.command-button-labeled {
+  min-height: 2rem;
+  padding: 0.32rem 0.68rem;
+}
+
+.command-icon {
+  width: 0.9rem;
+  height: 0.9rem;
+  flex: 0 0 auto;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.toast {
+  position: fixed;
+  right: 1.25rem;
+  bottom: 1.25rem;
+  z-index: 20;
+  max-width: min(24rem, calc(100vw - 2.5rem));
+  padding: 0.75rem 1rem;
+  border-radius: 999px;
+  color: var(--text);
+  background: rgba(15, 17, 24, 0.94);
+  border: 1px solid rgba(199, 210, 254, 0.24);
+  box-shadow: var(--shadow-soft);
+  opacity: 0;
+  transform: translateY(0.5rem);
+  pointer-events: none;
+  transition: opacity 140ms ease, transform 140ms ease;
+}
+
+.toast-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
 th {
   font-weight: 600;
   font-size: 0.82rem;

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -144,5 +144,8 @@
 {% endif %}
 </div>
 
+<script>
+  window.__DIUN_DASHBOARD__ = {% if dashboard %}{{ dashboard | tojson }}{% else %}null{% endif %};
+</script>
 <script src="/static/app.js" defer></script>
 {% endblock %}

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -9,6 +9,7 @@ export DASHBOARD_CRON_SANTIZED=$(echo "${DIUN_DASHBOARD_CRON_SCHEDULE:-7 */6 * *
 {
     echo "export DIUN_YAML_PATH=\"${DIUN_YAML_PATH:-/config/config.yml}\""
     echo "export DIUN_DASHBOARD_JSON_PATH=\"${DIUN_DASHBOARD_JSON_PATH:-/config/dashboard.json}\""
+    echo "export DIUN_DASHBOARD_COMMANDS_PATH=\"${DIUN_DASHBOARD_COMMANDS_PATH:-/config/dashboard.yml}\""
     echo "export DIUN_DASHBOARD_CRON_SCHEDULE=\"${DIUN_DASHBOARD_CRON_SCHEDULE:-7 */6 * * *}\""
     echo "export DIUN_CONTAINER_NAME=\"${DIUN_CONTAINER_NAME:-diun}\""
     echo "export LOG_LEVEL=\"${LOG_LEVEL:-INFO}\""

--- a/tests/test_dashboard_commands.py
+++ b/tests/test_dashboard_commands.py
@@ -1,0 +1,327 @@
+import json
+import shutil
+import subprocess
+from datetime import datetime, timezone
+
+from app.dashboard_snapshot import (
+    build_dashboard_snapshot,
+    load_dashboard_commands_from_yaml,
+)
+
+
+def test_load_dashboard_commands_from_yaml_returns_empty_for_missing_file(tmp_path):
+    assert load_dashboard_commands_from_yaml(tmp_path / "dashboard.yml") == []
+
+
+def test_load_dashboard_commands_from_yaml_returns_empty_for_empty_file(tmp_path):
+    config_path = tmp_path / "dashboard.yml"
+    config_path.write_text("\n")
+
+    assert load_dashboard_commands_from_yaml(config_path) == []
+
+
+def test_load_dashboard_commands_from_yaml_returns_empty_for_invalid_yaml(tmp_path):
+    config_path = tmp_path / "dashboard.yml"
+    config_path.write_text("dashboard: [commands:\n")
+
+    assert load_dashboard_commands_from_yaml(config_path) == []
+
+
+def test_load_dashboard_commands_from_yaml_parses_multiple_commands_and_defaults(tmp_path):
+    config_path = tmp_path / "dashboard.yml"
+    config_path.write_text(
+        """
+        dashboard:
+          commands:
+            - name: update-note
+              scope: service
+              label: Update note
+              icon: file-text
+              template: "{service}: {current} -> {latest}"
+            - name: refresh-digest
+              scope: service
+              label: Refresh digest
+              icon: made-up-icon
+              update_types:
+                - digest_refresh
+              template: "docker compose -p {compose_project} pull {compose_service}"
+            - name: refresh-all
+              scope: project
+              label: Refresh all
+              item_template: "docker compose pull {compose_service}"
+            - name: refresh-project
+              scope: project
+              label: Refresh project
+              template: "hc update {project}"
+        """
+    )
+
+    commands = load_dashboard_commands_from_yaml(config_path)
+
+    assert commands == [
+        {
+            "name": "update-note",
+            "scope": "service",
+            "label": "Update note",
+            "icon": "file-text",
+            "template": "{service}: {current} -> {latest}",
+        },
+        {
+            "name": "refresh-digest",
+            "scope": "service",
+            "label": "Refresh digest",
+            "icon": "code",
+            "update_types": ["digest_refresh"],
+            "template": "docker compose -p {compose_project} pull {compose_service}",
+        },
+        {
+            "name": "refresh-all",
+            "scope": "project",
+            "label": "Refresh all",
+            "icon": "code",
+            "item_template": "docker compose pull {compose_service}",
+            "join_with": " && ",
+            "prefix": "",
+            "suffix": "",
+        },
+        {
+            "name": "refresh-project",
+            "scope": "project",
+            "label": "Refresh project",
+            "icon": "code",
+            "template": "hc update {project}",
+        },
+    ]
+
+
+def test_build_dashboard_snapshot_includes_metadata_and_configured_commands():
+    generated_at = datetime(2026, 6, 10, 17, 0, tzinfo=timezone.utc)
+    snapshot = build_dashboard_snapshot(
+        [
+            {
+                "name": "linuxserver/sonarr:4.0.17",
+                "metadata": {
+                    "compose_project": "arr-stack",
+                    "compose_service": "sonarr",
+                    "image_repo": "linuxserver/sonarr",
+                    "current_tag": "4.0.17",
+                    "current_digest": "sha256:old",
+                    "release_notes_url": "https://github.com/linuxserver/docker-sonarr/releases",
+                },
+            }
+        ],
+        {
+            "linuxserver/sonarr": {
+                "latest": {"tag": "4.0.18", "digest": "sha256:new"}
+            }
+        },
+        dashboard_commands=[
+            {
+                "name": "bump-tags",
+                "scope": "service",
+                "label": "Bump tag",
+                "template": "yq -i {compose_service}",
+            }
+        ],
+        generated_at=generated_at,
+    )
+
+    assert snapshot["commands"] == [
+        {
+            "name": "bump-tags",
+            "scope": "service",
+            "label": "Bump tag",
+            "icon": "code",
+            "template": "yq -i {compose_service}",
+        }
+    ]
+    service = snapshot["projects"][0]["services"][0]
+    assert service["metadata"] == {
+        "compose_project": "arr-stack",
+        "compose_service": "sonarr",
+        "image_repo": "linuxserver/sonarr",
+        "current_tag": "4.0.17",
+        "current_digest": "sha256:old",
+        "release_notes_url": "https://github.com/linuxserver/docker-sonarr/releases",
+    }
+    assert service["release_notes_url"] == "https://github.com/linuxserver/docker-sonarr/releases"
+
+
+def run_app_js(js_expression: str):
+    if not shutil.which("node"):
+        raise AssertionError("node is required for dashboard command rendering tests")
+
+    script = f"""
+    const fs = require('fs');
+    const vm = require('vm');
+    const context = {{
+      console,
+      setTimeout: (fn) => fn(),
+      window: {{ setInterval: () => null, __DIUN_DASHBOARD__: null }},
+      document: {{
+        addEventListener: () => null,
+        getElementById: () => null,
+        createElement: () => ({{
+          className: '',
+          textContent: '',
+          remove: () => null,
+          classList: {{ add: () => null, remove: () => null }},
+        }}),
+        body: {{ appendChild: () => null }},
+      }},
+      navigator: {{ clipboard: {{ writeText: async () => null }} }},
+    }};
+    vm.createContext(context);
+    vm.runInContext(fs.readFileSync('app/static/app.js', 'utf8'), context);
+    const result = vm.runInContext({json.dumps(js_expression)}, context);
+    console.log(JSON.stringify(result));
+    """
+    completed = subprocess.run(
+        ["node", "-e", script],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    return json.loads(completed.stdout)
+
+
+def test_dashboard_template_rendering_replaces_raw_values_and_reports_missing_placeholders():
+    result = run_app_js(
+        """
+        (() => {
+          const rendered = renderCommandTemplate(
+            'docker compose -p {compose_project} pull {compose_service} && echo "{latest}"',
+            { compose_project: 'arr stack', compose_service: 'sonarr;rm -rf /', latest: '4.0.18' }
+          );
+          const missing = renderCommandTemplate('pull {compose_project} {missing_one} {missing_two}', { compose_project: 'arr-stack' });
+          return { rendered, missing };
+        })()
+        """
+    )
+
+    assert result["rendered"] == {
+        "text": 'docker compose -p arr stack pull sonarr;rm -rf / && echo "4.0.18"',
+        "missing": [],
+    }
+    assert result["missing"] == {
+        "text": None,
+        "missing": ["missing_one", "missing_two"],
+    }
+
+
+def test_dashboard_service_and_project_commands_render_with_update_type_filters():
+    result = run_app_js(
+        """
+        (() => {
+          const commands = [
+            { name: 'note', scope: 'service', label: 'Note', icon: 'file-text', template: '{service}: {latest}' },
+            { name: 'digest', scope: 'service', label: 'Digest', icon: 'refresh', update_types: ['digest_refresh'], template: 'pull {compose_service}' },
+            { name: 'bump-all', scope: 'project', label: 'Bump all', icon: 'rocket', update_types: ['tag_bump'], item_template: 'bump {compose_service} to {latest}', join_with: ' && ', suffix: ' && up {compose_project}' },
+            { name: 'refresh-all', scope: 'project', label: 'Refresh all', icon: 'nope', update_types: ['digest_refresh'], item_template: 'pull {compose_service}', join_with: ' && ', suffix: ' && up {compose_project}' },
+          ];
+          const project = {
+            name: 'arr-stack',
+            services: [
+              { service: 'bazarr', update_type: 'tag_bump', current: '1.5.0', latest: '1.6.0', metadata: { compose_project: 'arr-stack', compose_service: 'bazarr' } },
+              { service: 'sonarr', update_type: 'tag_bump', current: '4.0.18', latest: '4.0.19', metadata: { compose_project: 'arr-stack', compose_service: 'sonarr' } },
+              { service: 'qbittorrent', update_type: 'digest_refresh', current: '5.2.3', latest: '5.2.3', metadata: { compose_project: 'arr-stack', compose_service: 'qbittorrent' } },
+            ],
+          };
+          const serviceButtons = renderServiceCommandButtons(project.services[0], project, commands);
+          const projectButtons = renderProjectCommandButtons(project, commands);
+          const bumpAll = renderProjectCommand(commands[2], project);
+          const refreshAll = renderProjectCommand(commands[3], project);
+          return { serviceButtons, projectButtons, bumpAll, refreshAll };
+        })()
+        """
+    )
+
+    assert 'Copy Note command' in result["serviceButtons"]
+    assert 'bazarr: 1.6.0' in result["serviceButtons"]
+    assert 'Copy Digest command' not in result["serviceButtons"]
+    assert result["bumpAll"] == {
+        "text": "bump bazarr to 1.6.0 && bump sonarr to 4.0.19 && up arr-stack",
+        "missing": [],
+    }
+    assert result["refreshAll"] == {
+        "text": "pull qbittorrent && up arr-stack",
+        "missing": [],
+    }
+    assert 'data-icon="code"' in result["projectButtons"]
+
+
+def test_dashboard_project_template_renders_with_only_project_placeholder():
+    result = run_app_js(
+        """
+        (() => {
+          const project = {
+            name: 'arr-stack',
+            services: [
+              { service: 'qbittorrent', update_type: 'digest_refresh', current: '5.2.3', latest: '5.2.3', metadata: { compose_service: 'qbittorrent' } },
+            ],
+          };
+          const rendered = renderProjectCommand(
+            { name: 'refresh-project', scope: 'project', label: 'Refresh Project', update_types: ['digest_refresh'], template: 'hc update {project}' },
+            project
+          );
+          const missing = renderProjectCommand(
+            { name: 'bad-project', scope: 'project', label: 'Bad Project', update_types: ['digest_refresh'], template: 'hc update {service}' },
+            project
+          );
+          return { rendered, missing };
+        })()
+        """
+    )
+
+    assert result["rendered"] == {"text": "hc update arr-stack", "missing": []}
+    assert result["missing"] == {"text": None, "missing": ["service"]}
+
+
+def test_dashboard_project_item_template_skips_services_with_missing_placeholders():
+    result = run_app_js(
+        """
+        (() => {
+          const warnings = [];
+          console.warn = (...args) => warnings.push(args.join(' '));
+          const project = {
+            name: 'arr-stack',
+            services: [
+              { service: 'bazarr', update_type: 'tag_bump', current: '1.5.0', latest: '1.6.0', metadata: { compose_service: 'bazarr' } },
+              { service: 'sonarr', update_type: 'tag_bump', current: '4.0.18', latest: '4.0.19', metadata: {} },
+              { service: 'radarr', update_type: 'tag_bump', current: '6.1.0', latest: '6.1.1', metadata: { compose_service: 'radarr' } },
+            ],
+          };
+          const rendered = renderProjectCommand(
+            { name: 'bump-all', scope: 'project', label: 'Bump all', item_template: 'hc bump {compose_service} {latest}', join_with: ' && ', suffix: ' --apply' },
+            project
+          );
+          return { rendered, warnings };
+        })()
+        """
+    )
+
+    assert result["rendered"] == {
+        "text": "hc bump bazarr 1.6.0 && hc bump radarr 6.1.1 --apply",
+        "missing": [],
+    }
+    assert result["warnings"]
+    assert "Skipping command bump-all for service sonarr" in result["warnings"][0]
+
+
+def test_dashboard_command_buttons_disable_missing_placeholders():
+    result = run_app_js(
+        """
+        (() => {
+          const commands = [
+            { name: 'broken', scope: 'service', label: 'Broken', template: 'pull {compose_project} {compose_service}' },
+          ];
+          const project = { name: 'arr-stack' };
+          const service = { service: 'sonarr', update_type: 'tag_bump', current: '4.0.18', latest: '4.0.19', metadata: { compose_project: 'arr-stack' } };
+          return renderServiceCommandButtons(service, project, commands);
+        })()
+        """
+    )
+
+    assert 'disabled' in result
+    assert 'Missing placeholder: compose_service' in result
+    assert 'data-command-text=' not in result

--- a/tests/test_dashboard_snapshot.py
+++ b/tests/test_dashboard_snapshot.py
@@ -174,6 +174,13 @@ def test_build_dashboard_snapshot_reports_digest_refresh_when_latest_missing_fro
                     "update_type": "digest_refresh",
                     "current": "8.8.0",
                     "latest": "8.8.0",
+                    "metadata": {
+                        "compose_project": "paperless",
+                        "compose_service": "paperless-redis",
+                        "current_tag": "8.8.0",
+                        "current_digest": "sha256:027002f3",
+                        "current_repo_digests": '["sha256:027002f3"]',
+                    },
                 }
             ],
         }

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -15,3 +15,10 @@ def test_container_startup_generates_config_before_dashboard_snapshot():
     assert first_run_config in startup_section
     assert dashboard_refresh in startup_section
     assert startup_section.index(first_run_config) < startup_section.index(dashboard_refresh)
+
+
+def test_entrypoint_defaults_dashboard_commands_path_to_dashboard_yml():
+    script = ENTRYPOINT.read_text()
+
+    assert 'echo "export DIUN_DASHBOARD_COMMANDS_PATH=\\"${DIUN_DASHBOARD_COMMANDS_PATH:-/config/dashboard.yml}\\""' in script
+    assert 'DIUN_DASHBOARD_COMMANDS_PATH=\"${DIUN_DASHBOARD_COMMANDS_PATH:-${DIUN_YAML_PATH' not in script

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,4 +1,104 @@
+import importlib
+
+import yaml
+
 from app import main
+
+
+def test_default_dashboard_commands_path_is_dedicated_dashboard_yml(monkeypatch):
+    monkeypatch.delenv("DIUN_DASHBOARD_COMMANDS_PATH", raising=False)
+
+    reloaded = importlib.reload(main)
+
+    assert reloaded.DEFAULT_DASHBOARD_COMMANDS_PATH == "/config/dashboard.yml"
+
+
+def test_dashboard_commands_path_env_override(monkeypatch):
+    monkeypatch.setenv("DIUN_DASHBOARD_COMMANDS_PATH", "/custom/dashboard.yml")
+
+    reloaded = importlib.reload(main)
+
+    assert reloaded.DEFAULT_DASHBOARD_COMMANDS_PATH == "/custom/dashboard.yml"
+    monkeypatch.delenv("DIUN_DASHBOARD_COMMANDS_PATH", raising=False)
+    importlib.reload(main)
+
+
+def test_generate_dashboard_snapshot_from_yaml_does_not_read_commands_from_diun_yaml_by_default(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.yml"
+    dashboard_path = tmp_path / "dashboard.yml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "dashboard": {
+                    "commands": [
+                        {
+                            "name": "wrong-place",
+                            "scope": "service",
+                            "label": "Wrong place",
+                            "template": "{service}",
+                        }
+                    ]
+                }
+            }
+        )
+    )
+    calls = []
+
+    monkeypatch.setattr(main, "DEFAULT_DASHBOARD_COMMANDS_PATH", str(dashboard_path))
+    monkeypatch.setattr(
+        main,
+        "build_snapshot_from_entries",
+        lambda entries, container_name, dashboard_commands: calls.append(dashboard_commands)
+        or {"commands": dashboard_commands},
+    )
+
+    snapshot = main.generate_dashboard_snapshot_from_yaml(str(config_path), "diun")
+
+    assert snapshot == {"commands": []}
+    assert calls == [[]]
+
+
+def test_generate_dashboard_snapshot_from_yaml_loads_commands_from_dashboard_yml(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.yml"
+    dashboard_path = tmp_path / "dashboard.yml"
+    config_path.write_text("[]\n")
+    dashboard_path.write_text(
+        yaml.safe_dump(
+            {
+                "dashboard": {
+                    "commands": [
+                        {
+                            "name": "update-note",
+                            "scope": "service",
+                            "label": "Update note",
+                            "template": "{service}: {latest}",
+                        }
+                    ]
+                }
+            }
+        )
+    )
+
+    monkeypatch.setattr(main, "DEFAULT_DASHBOARD_COMMANDS_PATH", str(dashboard_path))
+    monkeypatch.setattr(
+        main,
+        "build_snapshot_from_entries",
+        lambda entries, container_name, dashboard_commands: {"commands": dashboard_commands},
+    )
+
+    snapshot = main.generate_dashboard_snapshot_from_yaml(str(config_path), "diun")
+
+    assert snapshot == {
+        "commands": [
+            {
+                "name": "update-note",
+                "scope": "service",
+                "label": "Update note",
+                "icon": "code",
+                "template": "{service}: {latest}",
+            }
+        ]
+    }
 
 
 def test_generate_dashboard_snapshot_from_yaml_uses_saved_config(monkeypatch):
@@ -31,7 +131,7 @@ def test_generate_dashboard_snapshot_from_yaml_uses_saved_config(monkeypatch):
     monkeypatch.setattr(
         main,
         "build_dashboard_snapshot",
-        lambda source_entries, latest, manifest_lookup=None: expected_snapshot,
+        lambda source_entries, latest, manifest_lookup=None, dashboard_commands=None: expected_snapshot,
     )
 
     def fail_if_called(*args, **kwargs):
@@ -104,7 +204,7 @@ def test_generate_targeted_dashboard_snapshot_filters_to_pending_services(monkey
     monkeypatch.setattr(
         main,
         "build_dashboard_snapshot",
-        lambda source_entries, latest, manifest_lookup=None: expected_snapshot,
+        lambda source_entries, latest, manifest_lookup=None, dashboard_commands=None: expected_snapshot,
     )
 
     snapshot = main.generate_targeted_dashboard_snapshot(

--- a/tests/test_yaml_helper.py
+++ b/tests/test_yaml_helper.py
@@ -164,6 +164,19 @@ def test_create_diun_yaml_keeps_notify_on_and_include_tags_as_yaml_lists():
     assert isinstance(loaded[0]["metadata"]["current_repo_digests"], str)
 
 
+def test_create_diun_yaml_does_not_emit_dashboard_commands():
+    container = make_container(
+        name="redis",
+        image_tag="redis:8.8.0",
+        repo_digests=["redis@sha256:027002f3"],
+    )
+
+    dumped = yaml.safe_dump(create_diun_yaml([container], m_all=True, compose_track=True))  # type: ignore[arg-type]
+
+    assert "dashboard:" not in dumped
+    assert "commands:" not in dumped
+
+
 def test_enrich_missing_current_digests_uses_matching_manifest_digest():
     entries = [
         {


### PR DESCRIPTION
Add Custom Action Buttons to the dashboard, allowing users to define
copy-to-clipboard actions in a dedicated `/config/dashboard.yml` file.

Highlights:
- add service-scoped and project-scoped dashboard commands
- support project commands using `item_template` or project-only `template`
- expose configured commands and service metadata in the dashboard API
- render service action buttons beside release notes links
- render project action buttons in project headers
- copy rendered raw command text only; no command execution
- handle missing placeholders gracefully
- skip invalid per-service project command fragments without failing the full project command
- add icon validation, fallback behavior, and supported icon documentation
- keep DIUN `config.yml` DIUN-only by loading dashboard commands from `dashboard.yml`
- document configuration, examples, safety behavior, placeholders, and available icons
- add regression coverage for command parsing, rendering, filtering, metadata, and config source behavior